### PR TITLE
Add some basic things to train the pipeline graph

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/R/List.R
+++ b/R/List.R
@@ -40,7 +40,7 @@ ListNamedEls = R6Class("ListNamedEls",
     },
 
 
-    print = function(...) catf(self$print_str),
+    print = function(...) BBmisc::catf(self$print_str),
 
     #FIXME this is bad, but in need this now
     map = function(f) lapply(self$xs, f),

--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -10,7 +10,7 @@ PipeOp = R6Class("PipeOp",
       private$.id = id
       private$.par_set = par_set
       #FIXME: we really need a funtion in ph2 now to get defaults
-      private$.par_vals = extractSubList(par_set$params, "default", simplify = FALSE)
+      private$.par_vals = BBmisc::extractSubList(par_set$params, "default", simplify = FALSE)
     },
 
 
@@ -50,13 +50,13 @@ PipeOp = R6Class("PipeOp",
 
 
     print = function(...) {
-      catf("PipeOp: <%s>", self$id)
-      catf("parvals: <%s>", listToShortString(self$par_vals))
-      catf("is_learnt=%s", self$is_learnt)
-      catf("Input: %s", listToShortString(self$inputs))
-      catf("Result: %s", listToShortString(self$result))
-      catf("Prev ops: %s", self$prev_ops$print_str)
-      catf("Next ops: %s", self$next_ops$print_str)
+      BBmisc::catf("PipeOp: <%s>", self$id)
+      BBmisc::catf("parvals: <%s>", BBmisc::listToShortString(self$par_vals))
+      BBmisc::catf("is_learnt=%s", self$is_learnt)
+      BBmisc::catf("Input: %s", BBmisc::listToShortString(self$inputs))
+      BBmisc::catf("Result: %s", BBmisc::listToShortString(self$result))
+      BBmisc::catf("Prev ops: %s", self$prev_ops$print_str)
+      BBmisc::catf("Next ops: %s", self$next_ops$print_str)
     },
     
     #FIXME: AB machen

--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -66,9 +66,19 @@ PipeOp = R6Class("PipeOp",
     },
     
     set_next = function(ops) {
+      
+      if(inherits(ops, "PipeOp")) {
+        # allows to call x$set_next(op1) rather than x$set_next(list(op1))
+        ops <- list(ops)
+      }
+      
       self$next_ops = OpList$new(ops)
       for (op in ops) {
-        op$prev_ops = OpList$new(list(self))
+        if(length(op$prev_ops) > 0) {
+          op$prev_ops$join_new(OpList$new(list(self)))
+        } else {
+          op$prev_ops = OpList$new(list(self))
+        }
       }
     },
 

--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -16,7 +16,7 @@ PipeOp = R6Class("PipeOp",
 
     train = function() {
       self$acquire_inputs()
-      messagef("Train op='%s'", self$id)
+      BBmisc::messagef("Train op='%s'", self$id)
       result = self$train2() 
       private$.result = result
       return(result)
@@ -24,7 +24,7 @@ PipeOp = R6Class("PipeOp",
     
     predict = function() {
       self$acquire_input()
-      messagef("Predict op='%s'", self$id)
+      BBmisc::messagef("Predict op='%s'", self$id)
       result = self$predict2() 
       private$.result = result
       return(result)

--- a/R/PipeOpFeatureUnion.R
+++ b/R/PipeOpFeatureUnion.R
@@ -3,13 +3,30 @@ PipeOpFeatureUnion = R6Class("PipeOpFeatureUnion",
   inherit = PipeOp,
   
   public = list(
-    initialize = function(nout) {
-      super$initialize("featureunion")
+    initialize = function(id = "featureunion") {
+      super$initialize(id)
     },
       
 
-    train2 = function(input) {
-      do.call(cbind, input)
+    train2 = function() {
+      
+      ## check if all target_names are equal
+      is_target_equal <- length(unique(vapply(
+        self$inputs,
+        function(x) digest::digest(x$target_names),
+        FUN.VALUE = ""
+      ))) == 1
+      
+      all_data <- lapply(self$inputs, function(x) {
+        x$data(cols = x$feature_names)
+      })
+      
+      input1 <- self$inputs[[1]]
+      targets <- input1$data(cols = task$target_names)
+      
+      data <- do.call(cbind, c(all_data, list(targets)))
+      db <- DataBackendDataTable$new(data)
+      TaskClassif$new(id = task$id, backend = db, target = task$target_names)
     },
 
     predict2 = function(input) {
@@ -17,8 +34,3 @@ PipeOpFeatureUnion = R6Class("PipeOpFeatureUnion",
     }
   )
 )
-
-
-
-
-

--- a/R/PipeOpLearner.R
+++ b/R/PipeOpLearner.R
@@ -24,7 +24,7 @@ PipeOpLearner = R6Class("PipeOpLearner",
       
       experiment$predict()
       d <- experiment$prediction[,-1]
-      colnames(d) <- c(task$target_names, "prediction")
+      colnames(d)[seq_along(task$target_names)] <- task$target_names
       
       db <- DataBackendDataTable$new(d)
       TaskClassif$new(id = task$id, backend = db, target = task$target_names)

--- a/R/PipeOpLearner.R
+++ b/R/PipeOpLearner.R
@@ -15,10 +15,19 @@ PipeOpLearner = R6Class("PipeOpLearner",
 
 
     train2 = function() {
-      assert_list(inputs, len = 1L, type = "Task")
-      task = inputs[[1L]]
-      private$.params = train(task, self$learner)
-      return(self$params)
+      assert_list(self$inputs, len = 1L, type = "Task")
+      task = self$inputs[[1L]]
+      
+      experiment <- Experiment$new(task = task, learner = self$learner)
+      experiment$train()
+      private$.params = experiment
+      
+      experiment$predict()
+      d <- experiment$prediction[,-1]
+      colnames(d) <- c(task$target_names, "prediction")
+      
+      db <- DataBackendDataTable$new(d)
+      TaskClassif$new(id = task$id, backend = db, target = task$target_names)
     },
 
     predict2 = function() {

--- a/R/PipeOpMultiplexer.R
+++ b/R/PipeOpMultiplexer.R
@@ -7,7 +7,7 @@ PipeOpMultiplexer = R6Class("PipeOpMultiplexer",
     ops = NULL,
 
     initialize = function(ops) {
-      op_ids = extractSubList(ops, "id")
+      op_ids = BBmisc::extractSubList(ops, "id")
       names(ops) = op_ids
       self$ops = ops
       ps = ParamSet$new(params = list(

--- a/R/Pipeline.R
+++ b/R/Pipeline.R
@@ -15,7 +15,7 @@ Pipeline = R6Class("Pipeline",
     # kopieren wir ops hier? ansontsen ändert sich der zustand beim training auch außen
     initialize = function(ops) {
       self$ops = ops
-      names(self$ops) = extractSubList(ops, "id")
+      names(self$ops) = BBmisc::extractSubList(ops, "id")
     },
 
     train = function(task) {
@@ -42,9 +42,9 @@ Pipeline = R6Class("Pipeline",
     },
 
     print = function(...) {
-      s = extractSubList(self$ops, "id")
+      s = BBmisc::extractSubList(self$ops, "id")
       s = BBmisc::collapse(s, "->")
-      catf("Pipeline: %s", s)
+      BBmisc::catf("Pipeline: %s", s)
     }
   )
 )

--- a/R/PipelineLearner.R
+++ b/R/PipelineLearner.R
@@ -1,0 +1,42 @@
+#' Traverse graphs and apply the function `fnc`
+traverseGraph <- function(root, fnc) {
+  #FIXME: check visited nodes
+  
+  front = OpList$new(list(root))
+  result_list <- list()
+  
+  while(length(front) > 0L) {
+    new_front = OpList$new()
+    for (i in seq_along(front)) {
+      op = front[[i]]
+      result_list[[op$id]] <- fnc(op)
+      
+      if(is.null(op$next_ops)) break
+      new_front$join_new(op$next_ops)
+    }
+    front = new_front
+  }
+  result_list
+}
+
+
+pipeline_gather_params <- function(graph) {
+  
+  all_params <- traverseGraph(
+    graph,
+    function(x) x$par_set$clone(deep = TRUE)$params
+  )
+  
+  all_params_named <- mapply(function(params_list, id) {
+    
+    lapply(params_list, function(x) {
+      
+      x <- x$clone(deep = TRUE)
+      x$id <- paste(id,x$id, sep =":")
+      x
+    })
+    
+  }, all_params, names(all_params), SIMPLIFY = FALSE)
+  
+  paradox::ParamSet$new(params = unlist(all_params_named))
+}

--- a/R/ops.concrete.R
+++ b/R/ops.concrete.R
@@ -37,8 +37,10 @@ PipeOpPCA = R6Class("PipeOpPCA",
       d = task$data()
       pcr = prcomp(as.matrix(d[, ..fn]), center = FALSE, scale. = FALSE)
       private$.params = pcr$rotation
-      d[, fn] = as.data.table(sc)
-      TaskClassif$new(id = task$id, data = d, target = task$target_names)
+      d[, fn] = as.data.table(pcr$x)
+      
+      db <- DataBackendDataTable$new(d)
+      TaskClassif$new(id = task$id, backend = db, target = task$target_names)
     },
 
     predict2 = function() {
@@ -78,7 +80,9 @@ PipeOpScaler = R6Class("PipeOpScaler",
         scale = attr(sc, "scaled:scale") %??% FALSE
       )
       d[, fn] = as.data.table(sc)
-      TaskClassif$new(id = task$id, data = d, target = task$target_names)
+      
+      db <- DataBackendDataTable$new(d)
+      TaskClassif$new(id = task$id, backend = db, target = task$target_names)
     },
 
     predict2 = function() {

--- a/R/ops.concrete.R
+++ b/R/ops.concrete.R
@@ -4,8 +4,8 @@ PipeOpNULL = R6Class("PipeOpNULL",
   inherit = PipeOp,
 
   public = list(
-    initialize = function() {
-      super$initialize("OpNULL")
+    initialize = function(id = "OpNULL") {
+      super$initialize(id)
     },
 
     train2 = function(inputs) {
@@ -24,8 +24,8 @@ PipeOpPCA = R6Class("PipeOpPCA",
   inherit = PipeOp,
 
   public = list(
-    initialize = function() {
-      super$initialize("pca")
+    initialize = function(id = "pca") {
+      super$initialize(id)
     },
 
     train2 = function() {
@@ -57,13 +57,13 @@ PipeOpScaler = R6Class("PipeOpScaler",
   inherit = PipeOp,
 
   public = list(
-    initialize = function() {
+    initialize = function(id = "scaler") {
 
       ps = ParamSet$new(params = list(
         ParamFlag$new("center", default = TRUE),
         ParamFlag$new("scale", default = TRUE)
       ))
-      super$initialize("scaler", ps)
+      super$initialize(id, ps)
     },
 
     train2 = function() {
@@ -100,12 +100,12 @@ PipeOpDownsample = R6Class("PipeOpDownsample",
   inherit = PipeOp,
 
   public = list(
-    initialize = function() {
+    initialize = function(id = "downsample") {
       ps = ParamSet$new(params = list(
         ParamNum$new("perc", default = 0.7, lower = 0, upper = 1),
         ParamLogical$new("stratify", default = FALSE)
       ))
-      super$initialize("downsample", ps)
+      super$initialize(id, ps)
     },
 
     train2 = function() {

--- a/R/ops.concrete.R
+++ b/R/ops.concrete.R
@@ -8,8 +8,9 @@ PipeOpNULL = R6Class("PipeOpNULL",
       super$initialize(id)
     },
 
-    train2 = function(inputs) {
-      return(inputs)
+    train2 = function() {
+      assert_list(self$inputs, len = 1L, type = "Task")
+      self$inputs[[1L]]
     },
 
     predict2 = function(inputs) {

--- a/R/trainGraph.R
+++ b/R/trainGraph.R
@@ -15,12 +15,9 @@ trainGraph = function(root, task) {
       if (op$can_fire) {
         op$train()
         
-        if(is.null(op$next_ops)) {
-          # there's no next operations
-          # so the loop can be stopped
-          break
+        if(!is.null(op$next_ops)) {
+          new_front$join_new(op$next_ops)
         }
-        new_front$join_new(op$next_ops)
       } else {
         new_front$add(op) 
       }

--- a/R/trainGraph.R
+++ b/R/trainGraph.R
@@ -5,22 +5,28 @@ trainGraph = function(root, task) {
   front = OpList$new(list(root))
 
   while(length(front) > 0L) {
-    messagef("front step, front=%s", front$print_str)
+    BBmisc::messagef("front step, front=%s", front$print_str)
     new_front = OpList$new()
     to_remove = integer(0L)
     for (i in seq_along(front)) {
       op = front[[i]]
       op$acquire_inputs()
-      messagef("checking front node %s, can_fire=%s", op$id, op$can_fire)
+      BBmisc::messagef("checking front node %s, can_fire=%s", op$id, op$can_fire)
       if (op$can_fire) {
         op$train()
+        
+        if(is.null(op$next_ops)) {
+          # there's no next operations
+          # so the loop can be stopped
+          break
+        }
         new_front$join_new(op$next_ops)
       } else {
         new_front$add(op) 
       }
     }
     front = new_front
-    messagef("front step done, front=%s", front$print_str)
+    BBmisc::messagef("front step done, front=%s", front$print_str)
   }
 }
 

--- a/attic/pipeoperator.R
+++ b/attic/pipeoperator.R
@@ -23,7 +23,7 @@
 
 #' @export
 `%>>%.PipeNode` = function(cpo1, cpo2) {
-  messagef("join %s >> %s", cpo1$id, cpo2$id)
+  BBmisc::messagef("join %s >> %s", cpo1$id, cpo2$id)
   #FIXME: add assert for cpo2
   if (inherits(cpo2, "PipeNode")) {
     compound2Ops(cpo1, cpo2)

--- a/attic/predictPipe.R
+++ b/attic/predictPipe.R
@@ -8,7 +8,7 @@ predictPipe = function(task, model) {
   repeat {
     curcpo = curnode$cpo
     curctrl = curnode$control
-    messagef("predict pipe el: id=%s; control=[%s]", curcpo$id, collapse(names(curctrl), ","))
+    BBmisc::messagef("predict pipe el: id=%s; control=[%s]", curcpo$id, collapse(names(curctrl), ","))
     input2 = formatInlist(input, dformat = curcpo$in.format)
     output = curcpo$predict(input2, curctrl)
     output2 = formatOutlist(output, dformat = curcpo$out.format, task = task)
@@ -21,7 +21,7 @@ predictPipe = function(task, model) {
       result.last$children[[1L]] = rn
     }
     ch = curnode$children
-    messagef("predict done. #children=%i", length(ch))
+    BBmisc::messagef("predict done. #children=%i", length(ch))
     if (length(ch) == 0L)
       break
     curnode = ch[[1]]

--- a/attic/trainPipe.R
+++ b/attic/trainPipe.R
@@ -3,7 +3,7 @@ trainPipe = function(task, pipe) {
   input = list(task = task)
   result = NULL
   repeat {
-    messagef("train pipe el: id=%s, par.vals=[%s]", current.node$id, listToShortString(current.node$par.vals))
+    messagef("train pipe el: id=%s, par.vals=[%s]", current.node$id, BBmisc::listToShortString(current.node$par.vals))
     input2 = formatInlist(input, dformat = current.node$in.format)
     input2$par.vals = current.node$par.vals
     output = current.node$train(input2)

--- a/attic/trainPipe.R
+++ b/attic/trainPipe.R
@@ -3,7 +3,7 @@ trainPipe = function(task, pipe) {
   input = list(task = task)
   result = NULL
   repeat {
-    messagef("train pipe el: id=%s, par.vals=[%s]", current.node$id, BBmisc::listToShortString(current.node$par.vals))
+    BBmisc::messagef("train pipe el: id=%s, par.vals=[%s]", current.node$id, BBmisc::listToShortString(current.node$par.vals))
     input2 = formatInlist(input, dformat = current.node$in.format)
     input2$par.vals = current.node$par.vals
     output = current.node$train(input2)
@@ -16,7 +16,7 @@ trainPipe = function(task, pipe) {
       result.last$children[[1L]] = rn
     }
     ch = current.node$children
-    messagef("train done. #children=%i", length(ch))
+    BBmisc::messagef("train done. #children=%i", length(ch))
     if (length(ch) == 0L)
       break
     current.node = ch[[1]]

--- a/mlr3pipelines.Rproj
+++ b/mlr3pipelines.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,19 @@
 library(testthat)
 library(mlrPipelines)
 
+load_github <- function(pkg, githubPath) {
+  # FIXME: it should be removed when 
+  # mlr3 and paradox will be available on CRAN
+  # and replaced with `library` call
+  if(!require(pkg, quietly = TRUE, character.only = TRUE)) {
+    devtools::install_github(githubPath)
+  }
+}
+
+load_github("paradox", "mlr-org/paradox")
+load_github("mlr3", "mlr-org/mlr3")
+
+library(paradox)
+library(mlr3)
+
 test_check("mlrPipelines")

--- a/tests/testthat/test_featureunion.R
+++ b/tests/testthat/test_featureunion.R
@@ -1,33 +1,38 @@
-# load_all("~/cos/paradox")
-# load_all("~/cos/mlr3")
-load_all()
-
-task = mlr_tasks$get("iris")
-dd = iris[, -5]
-nd = iris[, -5]
-
-op1 = PipeOpScaler$new()
-
-op2 = PipeOpFanOut$new(2)
-
-op3a = PipeOpPCA$new()
-
-op3b = PipeOpNULL$new()
-
-op4 = PipeOpFeatureUnion$new()
-
-lrn = mlr_learners$get("classif.rpart")
-op5 = PipeOpLearner$new(learner = lrn)
-
-op1$set_next(list(op2))
-
-op2$set_next(list(op3a, op3b))
-
-op4$set_prev(list(op3a, op3b))
-
-op4$set_next(list(op5))
-
-trainGraph(op1, task)
-
-
+test_that("featureunion - basic", {
+  
+  set.seed(123)
+  
+  task = mlr_tasks$get("iris")
+  dd = iris[, -5]
+  nd = iris[, -5]
+  
+  op1 = PipeOpScaler$new()
+  
+  op2a = PipeOpPCA$new()
+  op2b = PipeOpNULL$new()
+  
+  op3 = PipeOpFeatureUnion$new()
+  
+  lrn = mlr_learners$get("classif.rpart")
+  op4 = PipeOpLearner$new(learner = lrn)
+  
+  op1$set_next(list(op2a, op2b))
+  
+  op2a$set_next(list(op3))
+  op2b$set_next(list(op3))
+  
+  op3$set_next(list(op4))
+  
+  trainGraph(op1, task)
+  
+  model <- op4$params$model
+  
+  paramNamesFeatureUnion <- c(
+    "OpNULL.Petal.Width", "OpNULL.Petal.Length", "pca.Sepal.Length", 
+    "OpNULL.Sepal.Length", "pca.Sepal.Width", "OpNULL.Sepal.Width", 
+    "pca.Petal.Length")
+  
+  expect_equal(names(model$variable.importance), paramNamesFeatureUnion)
+  
+})
 

--- a/tests/testthat/test_pipes.R
+++ b/tests/testthat/test_pipes.R
@@ -1,15 +1,25 @@
 context("PipeOp")
 
-library(BBmisc)
-load_all("../paradox")
-load_all("../mlr3")
-load_all()
-
-test_that("PipeOp", {
+test_that("PipeOp1", {
+  
   task = mlr_tasks$get("iris")
   dd = iris[, -5]
   nd = iris[, -5]
+  
+  op1 = PipeOpScaler$new()
+  op2 = PipeOpPCA$new()
+  lrn = mlr_learners$get("classif.rpart")
+  op3 = PipeOpLearner$new(learner = lrn)
+  
+  op1$set_next(list(op2))
+  op2$set_next(list(op3))  
 
+  trainGraph(op1, task)  
+
+})
+
+test_that("PipeOp", {
+  
   op = PipeOpScaler$new()
   op$set_prev(list(task))
   dd2 = op$train()

--- a/tests/testthat/test_pipes.R
+++ b/tests/testthat/test_pipes.R
@@ -1,5 +1,19 @@
 context("PipeOp")
 
+test_that("Gather parameters", {
+  
+  op1 = PipeOpScaler$new("myscaler")
+  op2 = PipeOpPCA$new()
+  op1$set_next(list(op2))
+  
+  lrn = mlr_learners$get("classif.rpart")
+  op3 = PipeOpLearner$new(learner = lrn)
+  op2$set_next(list(op3))
+  
+  pipeline_gather_params(op1)
+  
+})
+
 test_that("PipeOp1", {
   
   task = mlr_tasks$get("iris")

--- a/tests/testthat/test_pipes.R
+++ b/tests/testthat/test_pipes.R
@@ -9,13 +9,17 @@ test_that("PipeOp1", {
   op1 = PipeOpScaler$new()
   op2 = PipeOpPCA$new()
   lrn = mlr_learners$get("classif.rpart")
+  lrn$predict_type <- "prob"
+  
   op3 = PipeOpLearner$new(learner = lrn)
   
   op1$set_next(list(op2))
   op2$set_next(list(op3))  
 
-  trainGraph(op1, task)  
+  trainGraph(op1, task)
 
+  op3$params$prediction
+  
 })
 
 test_that("PipeOp", {

--- a/tests/testthat/test_pipes.R
+++ b/tests/testthat/test_pipes.R
@@ -14,11 +14,9 @@ test_that("Gather parameters", {
   
 })
 
-test_that("PipeOp1", {
+test_that("PipeOp - simple pipe", {
   
   task = mlr_tasks$get("iris")
-  dd = iris[, -5]
-  nd = iris[, -5]
   
   op1 = PipeOpScaler$new()
   op2 = PipeOpPCA$new()
@@ -34,6 +32,30 @@ test_that("PipeOp1", {
 
   op3$params$prediction
   
+})
+
+test_that("PipeOp", {
+  
+  set.seed(123)
+  
+  task = mlr_tasks$get("iris")
+  
+  op1 = PipeOpPCA$new()
+  lrn1 <- mlr3:::LearnerClassifRpart$new(id = "l1")
+  lrn2 <- mlr3:::LearnerClassifRpart$new(id = "l2")
+  
+  lrn2$par_vals <- list("maxdepth" = 1)
+
+  op2a <- PipeOpLearner$new(lrn1)
+  op2b <- PipeOpLearner$new(lrn2)
+  
+  op1$set_next(list(op2a, op2b))
+  
+  trainGraph(op1, task)
+  
+  expect_true(!is.null(op2a$params$model))
+  expect_true(op2b$params$model)
+    
 })
 
 test_that("PipeOp", {


### PR DESCRIPTION
I took the existing code and tried to train the pipeline graph. I think I succeeded. It required some small changes here and there, but it works.

I think in the next step we should define the `PipelineLearner` class, which will behave just like the ordinary mlr3 learner and will be a wrapper around trainGraph and the graph definition.

So we should be able to initialize `PipelineLearner` by passing the first node of the graph (`PipelineLearner$new(root)`), or the list of steps (`PipelineLearner$new(list(op1, op2, op3, op3))`).