### PR TITLE
gunion and greplicate

### DIFF
--- a/R/graphOerators.R
+++ b/R/graphOerators.R
@@ -1,0 +1,28 @@
+# Union of graphs
+# takes multiple graphs and joins them "stacking" them one over the other
+# Outputs a Graph
+gunion = function(...) {
+  graphs = list(...)
+  assertList(graphs, types = "Graph")
+  start_nodes = unlist(lapply(graphs, function(x) x$lhs), recursive = FALSE)
+  Graph$new(start_nodes)
+}
+
+greplicate = function(graph, n) {
+  graphs = replicate(n, expr = graph$clone(deep = TRUE), simplify = FALSE)
+  Graph$new(unlist(lapply(graphs, function(g) g$lhs)))
+  updateIds = function(graph, id_append) {
+    for (id in graph$ids) {
+      graph$find_by_id(id)$id = paste0(graph$find_by_id(id)$id, id_append)
+    }
+  }
+}
+
+if (FALSE) {
+  g1 = PipeOpPCA$new() %>>% PipeOpScaler$new()
+  updateIds(g1, "bla")
+  ng = greplicate(g1, 10)
+  ng$lhs
+  ng$rhs
+}
+

--- a/R/graphOerators.R
+++ b/R/graphOerators.R
@@ -1,28 +1,67 @@
 # Union of graphs
-# takes multiple graphs and joins them "stacking" them one over the other
-# Outputs a Graph
+# takes an arbitrary amount of Graphs, GraphNodes and PipeOps as inputs and joins them by "stacking" them one over the other
+# Returns a single Graph
 gunion = function(...) {
   graphs = list(...)
+  graphs = map_if(graphs, function(x) inherits(x, "PipeOp"), function(x) GraphNode$new(x))
+  graphs = map_if(graphs, function(x) inherits(x, "GraphNode"), function(x) Graph$new(x))
   assertList(graphs, types = "Graph")
-  start_nodes = unlist(lapply(graphs, function(x) x$lhs), recursive = FALSE)
+  start_nodes = unlist(map(graphs, function(x) x$lhs), recursive = FALSE)
   Graph$new(start_nodes)
-}
-
-greplicate = function(graph, n) {
-  graphs = replicate(n, expr = graph$clone(deep = TRUE), simplify = FALSE)
-  Graph$new(unlist(lapply(graphs, function(g) g$lhs)))
-  updateIds = function(graph, id_append) {
-    for (id in graph$ids) {
-      graph$find_by_id(id)$id = paste0(graph$find_by_id(id)$id, id_append)
-    }
-  }
 }
 
 if (FALSE) {
   g1 = PipeOpPCA$new() %>>% PipeOpScaler$new()
-  updateIds(g1, "bla")
-  ng = greplicate(g1, 10)
-  ng$lhs
-  ng$rhs
+  g2 = PipeOpPCA$new(id = "pca2") %>>% PipeOpFeatureTransform$new()
+  g3 = PipeOpFeatureTransform$new(id = "blub") %>>% PipeOpScaler$new(id = "foo")
+  g4 = gunion(g1, g2, g3)
+
+  g5 = PipeOpPCA$new() %>>% PipeOpScaler$new()
+  g6 = PipeOpPCA$new(id = "pca2") %>>% PipeOpFeatureTransform$new()
+  g7 = PipeOpFeatureTransform$new(id = "blub") %>>% PipeOpScaler$new(id = "foo")
+  g8 = gunion(g5, g6)
+  g9 = gunion(g8, g7)
+
+  g10 = PipeOpPCA$new() %>>% PipeOpScaler$new()
+  g11 = PipeOpPCA$new("asdf")
+  g12 = GraphNode$new(PipeOpPCA$new("asdf2"))
+  g13 = gunion(g10, g11, g12)
+
+  g14 = gunion(PipeOpPCA$new(), PipeOpScaler$new())
+}
+
+
+#replicate a graph and joins it by a union
+# takes a Graph and integer n
+# returns a Graph
+#' @export
+greplicate = function(graph, n) {
+  useMethod("greplicate")
+}
+
+#' @export
+greplicate.PipeOp = function(graph, n) {
+  greplicate(GraphNode$new(graph), n)
+}
+
+#' @export
+greplicate.GraphNode = function(graph, n) {
+  greplicate(Graph$new(graph), n)
+}
+
+#' @export
+greplicate.Graph = function(graph, n) {
+  #FIXME: This needs to deep copy the graph and increment the id of each pipeop
+  graphs = replicate(n, expr = graph$clone(deep = TRUE), simplify = FALSE)
+  do.call(gunion, graphs)
+}
+
+
+
+if (FALSE) {
+  g1 = PipeOpPCA$new() %>>% PipeOpScaler$new()
+  greplicate(g1, 5) #Does not work yet
+  greplicate(PipeOpPCA$new(), 5)
+  greplicate(GraphNode$new(PipeOpPCA$new()), 5)
 }
 


### PR DESCRIPTION
fixes #62 and #63 

gunion works on graphs, GraphsNodes and PipeOps and mixtures

greplicate as a name istead of rep since name clash (and grep doesn't work as well :P )

greplicate does not work yet and requires a deep copy method and id changes