### PR TITLE
Less `innum` / `outnum` in PipeOps: varargs (input) and automatic copy (output)

### DIFF
--- a/R/Graph.R
+++ b/R/Graph.R
@@ -166,7 +166,7 @@ Graph = R6Class("Graph",
       }
       if (is.null(dst_channel)) {
         if (length(self$pipeops[[dst_id]]$input$name) > 1) {
-          stopf("src_channel must not be NULL if src_id pipeop has more than one output channel.")
+          stopf("dst_channel must not be NULL if src_id pipeop has more than one input channel.")
         }
         dst_channel = 1L
       }

--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -224,7 +224,12 @@ assert_connection_table = function(table) {
 # @param operation [character(1)] is either `"train"` or `"predict"`.
 check_types = function(self, data, direction, operation) {
   typetable = self[[direction]]
-  assert_list(data, len = nrow(typetable))
+  if (direction == "input" && "..." %in% typetable$name) {
+    assert_list(data, min.len = nrow(typetable) - 1)
+    typetable = typetable[rep(1:.N, ifelse(name == "...", length(data) - nrow(typetable) + 1, 1))]
+  } else {
+    assert_list(data, len = nrow(typetable))
+  }
   for (idx in seq_along(data)) {
     typereq = typetable[[operation]][idx]
     if (typereq != "*") {

--- a/R/PipeOpCopy.R
+++ b/R/PipeOpCopy.R
@@ -4,7 +4,8 @@
 #' @format [`R6Class`] object inheriting from [`PipeOp`].
 #'
 #' @description
-#'   Copies its input `outnum` times.
+#'   Copies its input `outnum` times. This should usually not be needed,
+#'   because copying happens automatically.
 #' @section Methods:
 #' * `PipeOpEnsemble$new(outnum, id)` \cr
 #'   (`numeric(1)`, `character(1)`) -> `self` \cr

--- a/R/PipeOpEnsemble.R
+++ b/R/PipeOpEnsemble.R
@@ -103,7 +103,7 @@ PipeOpModelAvg = R6Class("PipeOpModelAvg",
   )
 )
 
-register_pipeop("modelavg", PipeOpModelAvg, list("N"))
+register_pipeop("modelavg", PipeOpModelAvg)
 
 
 #' @title PipeOpMajorityVote
@@ -195,5 +195,5 @@ PipeOpMajorityVote = R6Class("PipeOpMajorityVote",
   )
 )
 
-register_pipeop("majorityvote", PipeOpMajorityVote, list("N"))
+register_pipeop("majorityvote", PipeOpMajorityVote)
 

--- a/R/PipeOpEnsemble.R
+++ b/R/PipeOpEnsemble.R
@@ -5,9 +5,12 @@
 #' @description
 #' Parent class for PipeOps that aggregate a list of predictions.
 #' @section Methods:
-#' * `PipeOpEnsemble$new(innum, id)` \cr
+#' * `PipeOpEnsemble$new(innum = 0, id)` \cr
 #'   (`numeric(1)`, `character(1)`) -> `self` \cr
 #'   Constructor. `innum` determines the number of input channels.
+#'   If `innum` is 0 (default), a vararg input
+#'   channel is created that can take an arbitrary number of inputs.
+#'
 #' @family PipeOps
 #' @include PipeOp.R
 #' @export
@@ -59,14 +62,14 @@ check_weights = function(innum) {
 #' Averages its input (a `list` of `PredictionRegr`).
 #' Only used for regression `Prediction`s.
 #' Weights can be set by the user, if none are provided, defaults to
-#' equal weights `rep(1/innum, innum)` for each prediction.
+#' equal weights for each prediction.
 #' Offers a `$weights` slot to set/get weights for each learner.
 #' Returns a single `PredictionRegr`.
 #' Defaults to equal weights for each model.
 #'
 #' @family PipeOps
 #' @examples
-#' op = PipeOpModelAvg$new(3)
+#' op = PipeOpModelAvg$new()
 #' @export
 PipeOpModelAvg = R6Class("PipeOpModelAvg",
   inherit = PipeOpEnsemble,
@@ -119,7 +122,7 @@ register_pipeop("modelavg", PipeOpModelAvg)
 #' or averages probabilities if `predict_type` is `"prob"`.
 #' Returns a single `PredictionClassif`.
 #' Weights can be set by the user, if none are provided, defaults to
-#' equal weights `rep(1/innum, innum)` for each prediction.
+#' equal weights for each prediction.
 #' Used for classification `Prediction`s.
 #' Defaults to equal weights for each model.
 #'

--- a/R/PipeOpFeatureUnion.R
+++ b/R/PipeOpFeatureUnion.R
@@ -24,12 +24,13 @@ PipeOpFeatureUnion = R6Class("PipeOpFeatureUnion",
   inherit = PipeOp,
   public = list(
     assert_targets_equal = NULL,
-    initialize = function(innum, id = "featureunion", param_vals = list(), assert_targets_equal = TRUE) {
-      assert_int(innum, lower = 1)
+    initialize = function(innum = 0, id = "featureunion", param_vals = list(), assert_targets_equal = TRUE) {
+      assert_int(innum, lower = 0)
       assert_flag(assert_targets_equal)
       self$assert_targets_equal = assert_targets_equal
+      inname = if (innum) rep_suffix("input", innum) else "..."
       super$initialize(id, param_vals = param_vals,
-        input = data.table(name = rep_suffix("input", innum), train = "Task", predict = "Task"),
+        input = data.table(name = inname, train = "Task", predict = "Task"),
         output = data.table(name = "output", train = "Task", predict = "Task")
       )
     },

--- a/R/PipeOpFeatureUnion.R
+++ b/R/PipeOpFeatureUnion.R
@@ -12,9 +12,10 @@
 #'   disagree.
 #'
 #' @section Methods:
-#' * `PipeOpFeatureUnion$new(innum, id = "featureunion", param_vals = list(), assert_targets_equal = TRUE)` \cr
+#' * `PipeOpFeatureUnion$new(innum = 0, id = "featureunion", param_vals = list(), assert_targets_equal = TRUE)` \cr
 #'   (`numeric(1)`, `character(1)`, named `list`, `logical(1)`) -> `self` \cr
-#'   Constructor. `innum` determines the number of input channels. If `assert_targets_equal` is `TRUE` (Default),
+#'   Constructor. `innum` determines the number of input channels. If `innum` is 0 (default), a vararg input
+#'   channel is created that can take an arbitrary number of inputs. If `assert_targets_equal` is `TRUE` (Default),
 #'   task target column names are checked for agreement. Disagreeing target column names are usually a
 #'   bug, so this should often be left at the default.
 #' @family PipeOps

--- a/R/PipeOpFeatureUnion.R
+++ b/R/PipeOpFeatureUnion.R
@@ -46,7 +46,7 @@ PipeOpFeatureUnion = R6Class("PipeOpFeatureUnion",
   )
 )
 
-register_pipeop("featureunion", PipeOpFeatureUnion, list("N"))
+register_pipeop("featureunion", PipeOpFeatureUnion)
 
 cbind_tasks = function(inputs, assert_targets_equal) {
   task = inputs[[1L]]

--- a/R/PipeOpUnBranch.R
+++ b/R/PipeOpUnBranch.R
@@ -7,11 +7,12 @@
 #' Used to bring together different paths created by [`PipeOpBranch`].
 #'
 #' @section Methods:
-#' * `PipeOpUnbranch$new(options, id = "unbranch")` \cr
+#' * `PipeOpUnbranch$new(options = 0, id = "unbranch")` \cr
 #'   (`numeric(1)` | `character`, `character(1)`) -> `self` \cr
-#'   Constructor. If `options` is an integer number, it determines the number of
-#'   input channels that are created, named `input1`...`input<n>`. If `options` is a
-#'   `character`, it determines the names of channels directly.
+#'   Constructor. If `options` is 0, only one vararg input channel is created that can
+#'   be connected to an arbitrary number of branches. If `options` is a positive integer
+#'   number, it determines the number of input channels that are created, named
+#'   `input1`...`input<n>`. If `options` is a `character`, it determines the names of channels directly.
 #'
 #' @section Details:
 #' Creates a PipeOp with multiple input channels that can be used to

--- a/R/PipeOpUnBranch.R
+++ b/R/PipeOpUnBranch.R
@@ -60,4 +60,4 @@ PipeOpUnbranch = R6Class("PipeOpUnbranch",
   )
 )
 
-register_pipeop("unbranch", PipeOpUnbranch, list("N"))
+register_pipeop("unbranch", PipeOpUnbranch)

--- a/R/PipeOpUnBranch.R
+++ b/R/PipeOpUnBranch.R
@@ -31,36 +31,31 @@
 PipeOpUnbranch = R6Class("PipeOpUnbranch",
   inherit = PipeOp,
   public = list(
-    initialize = function(options, id = "unbranch", param_vals = list()) {
+    initialize = function(options = 0, id = "unbranch", param_vals = list()) {
       assert(
-        check_int(options, lower = 1),
+        check_int(options, lower = 0),
         check_character(options, min.len = 1, any.missing = FALSE)
       )
       if (is.numeric(options)) {
-        options = round(options)
-        innum = options
-      } else {
-        innum = length(options)
+        if (options) {
+          options = rep_suffix("input", round(options))
+        } else {
+          options = "..."
+        }
       }
       super$initialize(id, param_vals = param_vals,
-        input = data.table(name = rep_suffix("input", innum), train = "*", predict = "*"),
+        input = data.table(name = options, train = "*", predict = "*"),
         output = data.table(name = "output", train = "*", predict = "*")
       )
     },
 
     train = function(inputs) {
-      assert_list(inputs, len = self$innum)
       self$state = list()
-      result = filter_noop(inputs)
-      assert_list(result, len = 1)
-      return(result)
+      filter_noop(inputs)
     },
 
     predict = function(inputs) {
-      assert_list(inputs, len = self$innum)
-      result = filter_noop(inputs)
-      assert_list(result, len = 1)
-      return(result)
+      filter_noop(inputs)
     }
   )
 )

--- a/R/mlr_pipeops.R
+++ b/R/mlr_pipeops.R
@@ -55,7 +55,7 @@ as.data.table.DictionaryPipeOp = function(x, ...) {
     } else {
       l1 = l2 = x$get(key)
     }
-    if (nrow(l1$input) == nrow(l2$input)) {
+    if (nrow(l1$input) == nrow(l2$input) && "..." %nin% l1$input$name) {
       innum = nrow(l1$input)
     } else {
       innum = NA

--- a/R/operators.R
+++ b/R/operators.R
@@ -35,20 +35,23 @@
   g2 = assert_graph(g2, coerce = TRUE)
   g1out = g1$output
   g2in = g2$input
-  if (nrow(g1out) != nrow(g2in)) {
+  if (nrow(g1out) != 1 && nrow(g1out) != nrow(g2in) && !(nrow(g2in) == 1 && g2in$channel.name == "...")) {
     stopf("Graphs / PipeOps to be connected have mismatching number of inputs / outputs.")
   }
   g = gunion(list(g1, g2))
 
+
   # check that types agree
-  for (row in seq_len(nrow(g1out))) {
-    if (!are_types_compatible(g1out$train[row], g2in$train[row])) {
+  for (row in seq_len(max(nrow(g1out), nrow(g2in)))) {
+    outrow = min(nrow(g1out), row)
+    inrow = min(nrow(g2in), row)
+    if (!are_types_compatible(g1out$train[outrow], g2in$train[inrow])) {
       stopf("Output type of PipeOp %s during training (%s) incompatible with input type of PipeOp %s (%s)",
-        g1out$op.id[row], g1out$train[row], g2in$op.id[row], g2in$train[row])
+        g1out$op.id[outrow], g1out$train[outrow], g2in$op.id[inrow], g2in$train[inrow])
     }
-    if (!are_types_compatible(g1out$predict[row], g2in$predict[row])) {
+    if (!are_types_compatible(g1out$predict[outrow], g2in$predict[inrow])) {
       stopf("Output type of PipeOp %s during prediction (%s) incompatible with input type of PipeOp %s (%s)",
-        g1out$op.id[row], g1out$predict[row], g2in$op.id[row], g2in$predict[row])
+        g1out$op.id[outrow], g1out$predict[outrow], g2in$op.id[inrow], g2in$predict[inrow])
     }
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,6 @@
 rep_suffix = function(x, n) {
   # priority here is "easy to enter by hand", not "can reasonably be sorted alphabetically" which NEVER happens
-  paste0(x, seq_len(n))
+  sprintf("%s%s", x, seq_len(n))
 }
 
 calculate_collimit = function(colwidths, outwidth) {

--- a/attic/experiments.R
+++ b/attic/experiments.R
@@ -17,14 +17,13 @@ devtools::load_all("mlr3pipelines")
 
 tools::buildVignettes(dir = "mlr3pipelines")
 
-
 testthat::test_package("mlr3pipelines")
 
-testthat::test_package("mlr3pipelines", filter = "backup")
+testthat::test_package("mlr3pipelines", filter = "Graph")
 
-testthat::test_package("mlr3pipelines", filter = "typecheck")
+testthat::test_package("mlr3pipelines", filter = "doublearrow")
 
-testthat::test_package("mlr3pipelines", filter = "dictionary")
+testthat::test_package("mlr3pipelines", filter = "multichannel")
 
 
 testthat::test_package("mlr3pipelines", filter = "^_[a-d].*")

--- a/tests/testthat/helper_test_pipeops.R
+++ b/tests/testthat/helper_test_pipeops.R
@@ -59,3 +59,26 @@ PipeOpDebugMulti = R6Class("PipeOpDebugMulti",
         output = data.table(name = outputs, train = "*", predict = "*"))
     })
 )
+
+
+VarargPipeop = R6Class("VarargPipeop",
+  inherit = PipeOp,
+  public = list(
+    initialize = function(id = "vararg", innum = 0, param_vals = list()) {
+      super$initialize(id, param_vals = param_vals,
+        input = data.table(name = c("...", rep_suffix("input", innum)), train = "*", predict = "*"),
+        output = data.table(name = "output", train = "*", predict = "*")
+      )
+    },
+
+    train = function(inputs) {
+      self$state = inputs
+      list(inputs)
+    },
+
+    predict = function(inputs) {
+      self$state = inputs
+      list(inputs)
+    }
+  )
+)

--- a/tests/testthat/test_Graph.R
+++ b/tests/testthat/test_Graph.R
@@ -36,8 +36,10 @@ test_that("linear graph", {
 
   expect_graph(g)
 
-  expect_error(g$add_edge("subsample", "classif.rpart"),
-    "Channel.*output.*of node.*subsample.*already connected to channel.*input.*of node pca")
+  g$add_edge("subsample", "classif.rpart")
+
+  expect_error(g$add_edge("pca", "classif.rpart"),
+    "Channel.*output.*of node.*subsample.*already connected to channel.*input.*of node classif.rpart")
 
   expect_error(g$add_pipeop(op_lrn), "PipeOp with id.*rpart.*already in Graph")
 

--- a/tests/testthat/test_doublearrow.R
+++ b/tests/testthat/test_doublearrow.R
@@ -13,7 +13,8 @@ test_that("Simple ops do what we expect", {
   expect_class(g, "Graph")
   expect_equal(g$rhs[[1]], p3$id)
 
-  expect_error(p1 %>>% gunion(list(p2, p3)), "mismatching number of inputs / outputs")
+  expect_graph(p1 %>>% gunion(list(p2, p3)))
+  expect_error(gunion(list(p2, p3)) %>>% p1, "mismatching number of inputs / outputs")
 
   g = p1 %>>% PipeOpBranch$new(2) %>>% gunion(list(p2, p3))
   expect_class(g, "Graph")

--- a/tests/testthat/test_multichannels.R
+++ b/tests/testthat/test_multichannels.R
@@ -1,0 +1,194 @@
+context("multichannels")
+
+test_that("adding multiple edges to output channels works", {
+
+  graph = Graph$new()$add_pipeop("scale")$add_pipeop("pca")$add_pipeop("subsample")
+
+  graph$add_edge("scale", "subsample")$add_edge("scale", "pca")
+
+  expect_output(print(graph), c("scale.*subsample,pca.*\n.*subsample.*scale.*\n.*pca.*scale"))
+
+  pdf(file = NULL) # don't show plot. It is annoying.
+  graph$plot()
+  dev.off()
+
+})
+
+test_that("doublearrow with one output to many input works as expected", {
+
+  g1 = "scale" %>>% gunion(list("pca", "subsample"))
+  g2 = Graph$new()$add_pipeop("scale")$add_pipeop("pca")$add_pipeop("subsample")$
+    add_edge("scale", "pca")$add_edge("scale", "subsample")
+
+  expect_equal(g1, g2)
+
+  expect_error(gunion(list("scale", "pca")) %>>% gunion(list("null", "subsample", "select")),
+    "mismatching number of inputs / outputs")
+
+})
+
+test_that("multiple edges on output channel copies, as expected", {
+  graph = Graph$new()$add_pipeop("scale")$add_pipeop("pca")$add_pipeop("subsample")
+
+  graph$add_edge("scale", "subsample")$add_edge("scale", "pca")
+
+  expect_list(graph$train(task), types = "Task", any.missing = FALSE, len = 2)
+
+  nullgraph = mlr_pipeops$get("null", id = "null1") %>>%
+    gunion(list(mlr_pipeops$get("null", id = "null2"), mlr_pipeops$get("null", id = "null3")))
+
+  tsk0 = mlr_tasks$get("iris")
+  tsk_clone = tsk0$clone(deep = TRUE)
+
+  tmp = nullgraph$train(tsk0)
+
+  tsk1 = tmp[[1]]
+  tsk2 = tmp[[2]]
+
+  expect_identical(tsk0, tsk1)
+  expect_identical(tsk0, tsk2)
+
+  tmp = nullgraph$predict(tsk0)
+
+  tsk1 = tmp[[1]]
+  tsk2 = tmp[[2]]
+
+  expect_identical(tsk0, tsk1)
+  expect_identical(tsk0, tsk2)
+
+  graph = "null" %>>% gunion(list(
+    mlr_pipeops$get("scale", id = "s1", param_vals = list(scale = TRUE, center = FALSE)),
+    mlr_pipeops$get("scale", id = "s2", param_vals = list(scale = FALSE, center = TRUE))))
+
+  tmp = graph$train(tsk0)
+
+  stsk = tmp[[1]]
+  ctsk = tmp[[2]]
+
+  expect_equal(sapply(ctsk$data(cols = ctsk$feature_names), mean),
+    c(Petal.Length = 0, Petal.Width = 0, Sepal.Length = 0, Sepal.Width = 0))
+
+  expect_equal(sapply(stsk$data(cols = stsk$feature_names), function(x) sum(x^2) / (length(x) - 1)),
+    c(Petal.Length = 1, Petal.Width = 1, Sepal.Length = 1, Sepal.Width = 1))
+
+  tmp = graph$predict(tsk0)
+
+  stsk = tmp[[1]]
+  ctsk = tmp[[2]]
+
+  expect_equal(sapply(ctsk$data(cols = ctsk$feature_names), mean),
+    c(Petal.Length = 0, Petal.Width = 0, Sepal.Length = 0, Sepal.Width = 0))
+
+  expect_equal(sapply(stsk$data(cols = stsk$feature_names), function(x) sum(x^2) / (length(x) - 1)),
+    c(Petal.Length = 1, Petal.Width = 1, Sepal.Length = 1, Sepal.Width = 1))
+
+  expect_identical(tsk0, tsk1)  # input task not changed
+
+  expect_deep_clone(tsk0, tsk_clone)
+
+})
+
+test_that("adding multiple edges to vararg input channel works", {
+
+  graph = Graph$new()$add_pipeop("scale")$add_pipeop("pca")$add_pipeop(VarargPipeop$new())
+
+  graph$add_edge("scale", "vararg")$add_edge("pca", "vararg")
+
+  expect_output(print(graph), c("scale.*vararg.*\n.*pca.*vararg.*\n.*vararg.*scale,pca"))
+
+  pdf(file = NULL) # don't show plot. It is annoying.
+  graph$plot()
+  dev.off()
+
+  graph = Graph$new()$
+    add_pipeop("scale")$add_pipeop("pca")$
+    add_pipeop("subsample")$add_pipeop("select")$
+    add_pipeop(VarargPipeop$new(innum = 2))
+
+  expect_error(graph$add_edge("scale", "vararg"), "dst_channel must not be NULL")
+
+  graph$add_edge("scale", "vararg", dst_channel = "...")$
+    add_edge("pca", "vararg", dst_channel = "...")$
+    add_edge("subsample", "vararg", dst_channel = "input1")$
+    add_edge("select", "vararg", dst_channel = "input2")
+
+
+  expect_output(print(graph), c("scale.*vararg.*\n.*pca.*vararg.*\n.*subsample.*vararg.*\n.*select.*vararg.*\n.*vararg.*scale,pca,subsample,select"))
+
+  pdf(file = NULL) # don't show plot. It is annoying.
+  graph$plot()
+  dev.off()
+
+})
+
+test_that("doublearrow with many output to vararg input works as expected", {
+
+  g1 = gunion(list("scale", "pca")) %>>% VarargPipeop$new()
+  g2 = Graph$new()$add_pipeop("scale")$add_pipeop("pca")$add_pipeop(VarargPipeop$new())$
+    add_edge("scale", "vararg")$add_edge("pca", "vararg")
+
+  expect_equal(g1, g2)
+
+  g1 = gunion(list("scale", "pca")) %>>% VarargPipeop$new(innum = 1)
+  g2 = Graph$new()$add_pipeop("scale")$add_pipeop("pca")$add_pipeop(VarargPipeop$new(innum = 1))$
+    add_edge("scale", "vararg", dst_channel = "...")$add_edge("pca", "vararg", dst_channel = "input1")
+
+  expect_equal(g1, g2)
+
+  expect_error(gunion(list("scale", "pca", "select", "subsample")) %>>% VarargPipeop$new(innum = 2),
+    "mismatching number of inputs / outputs")
+
+})
+
+test_that("vararg passes args through as it should", {
+
+  nullgraph = gunion(list(mlr_pipeops$get("null", id = "null1"), mlr_pipeops$get("null", id = "null2"))) %>>% VarargPipeop$new()
+
+  expect_equal(nullgraph$train(1)[[1]], list(`...` = 1, `...` = 1))
+
+  graph = gunion(list(
+    mlr_pipeops$get("scale", id = "s1", param_vals = list(scale = TRUE, center = FALSE)),
+    mlr_pipeops$get("scale", id = "s2", param_vals = list(scale = FALSE, center = TRUE)))) %>>%
+    VarargPipeop$new()
+
+  tsk0 = tsk1 = mlr_tasks$get("iris")
+  tsk_clone = tsk0$clone(deep = TRUE)
+
+  tmp = graph$train(tsk0)[[1]]
+
+  stsk = tmp[[1]]
+  ctsk = tmp[[2]]
+
+  expect_equal(sapply(ctsk$data(cols = ctsk$feature_names), mean),
+    c(Petal.Length = 0, Petal.Width = 0, Sepal.Length = 0, Sepal.Width = 0))
+
+  expect_equal(sapply(stsk$data(cols = stsk$feature_names), function(x) sum(x^2) / (length(x) - 1)),
+    c(Petal.Length = 1, Petal.Width = 1, Sepal.Length = 1, Sepal.Width = 1))
+
+  tmp = graph$predict(tsk0)[[1]]
+
+  stsk = tmp[[1]]
+  ctsk = tmp[[2]]
+
+  expect_equal(sapply(ctsk$data(cols = ctsk$feature_names), mean),
+    c(Petal.Length = 0, Petal.Width = 0, Sepal.Length = 0, Sepal.Width = 0))
+
+  expect_equal(sapply(stsk$data(cols = stsk$feature_names), function(x) sum(x^2) / (length(x) - 1)),
+    c(Petal.Length = 1, Petal.Width = 1, Sepal.Length = 1, Sepal.Width = 1))
+
+  expect_identical(tsk0, tsk1)  # input task not changed
+  expect_deep_clone(tsk0, tsk_clone)
+
+
+  nullgraph = gunion(list(
+    mlr_pipeops$get("null", id = "null1"),
+    mlr_pipeops$get("null", id = "null2"),
+    mlr_pipeops$get("null", id = "null3")))$
+    add_pipeop(VarargPipeop$new(innum = 1))$
+    add_edge("null1", "vararg", dst_channel = "...")$
+    add_edge("null3", "vararg", dst_channel = "...")$
+    add_edge("null2", "vararg", dst_channel = "input1")
+
+  expect_equal(nullgraph$train(list(1, 2, 3), single_input = FALSE)[[1]], list(`...` = 1, `...` = 3, input1 = 2))
+
+})

--- a/tests/testthat/test_multichannels.R
+++ b/tests/testthat/test_multichannels.R
@@ -32,7 +32,7 @@ test_that("multiple edges on output channel copies, as expected", {
 
   graph$add_edge("scale", "subsample")$add_edge("scale", "pca")
 
-  expect_list(graph$train(task), types = "Task", any.missing = FALSE, len = 2)
+  expect_list(graph$train(mlr_tasks$get("iris")), types = "Task", any.missing = FALSE, len = 2)
 
   nullgraph = mlr_pipeops$get("null", id = "null1") %>>%
     gunion(list(mlr_pipeops$get("null", id = "null2"), mlr_pipeops$get("null", id = "null3")))

--- a/tests/testthat/test_pipeop_ensemble.R
+++ b/tests/testthat/test_pipeop_ensemble.R
@@ -5,12 +5,16 @@ test_that("PipeOpEnsemble - basic properties", {
   expect_pipeop(op)
   expect_pipeop_class(PipeOpEnsemble, list(3, "ensemble", param_vals = list()))
   expect_pipeop_class(PipeOpEnsemble, list(1, "ensemble", param_vals = list()))
-  expect_error(PipeOpEnsemble$new(0))
+  expect_pipeop_class(PipeOpEnsemble, list(0, "ensemble", param_vals = list()))
 
   truth = rnorm(70)
   prds = replicate(4, PredictionRegr$new(row_ids = seq_len(70), truth = truth, response = truth + rnorm(70, sd = 0.1)))
   expect_list(train_pipeop(op, prds), len = 1)
   expect_error(predict_pipeop(op, prds))
+
+  op = PipeOpEnsemble$new(0, "ensemble", param_vals = list())
+  expect_pipeop(op)
+
 })
 
 test_that("PipeOpWeightedModelAvg - train and predict", {
@@ -29,6 +33,20 @@ test_that("PipeOpWeightedModelAvg - train and predict", {
   expect_list(train_pipeop(po, prds), len = 1)
   out = predict_pipeop(po, prds)
   expect_equal(out, list(prds[[3]]))
+
+
+  po = PipeOpModelAvg$new()
+  expect_pipeop(po)
+  expect_list(train_pipeop(po, prds), len = 1)
+  out = predict_pipeop(po, prds)
+
+  # Returns the same if weights are 1, rest 0
+  po = PipeOpModelAvg$new()
+  po$weights = c(0, 0, 1, 0)
+  expect_list(train_pipeop(po, prds), len = 1)
+  out = predict_pipeop(po, prds)
+  expect_equal(out, list(prds[[3]]))
+
 })
 
 ## test_that("PipeOpNlOptModelAvg - response - train and predict", {
@@ -62,6 +80,21 @@ test_that("PipeOpWeightedMajorityVote - response -train and predict", {
   out = predict_pipeop(po, prds)
   expect_class(out[[1]], "PredictionClassif")
   expect_equal(out[[1]]$data, prds[[4]]$data)
+
+
+  po = PipeOpMajorityVote$new()
+  expect_pipeop(po)
+  expect_list(train_pipeop(po, prds), len = 1)
+  out = predict_pipeop(po, prds)
+  expect_class(out[[1]], "PredictionClassif")
+
+  po = PipeOpMajorityVote$new()
+  po$weights = c(0, 0, 0, 1)
+  expect_list(train_pipeop(po, prds), len = 1)
+  out = predict_pipeop(po, prds)
+  expect_class(out[[1]], "PredictionClassif")
+  expect_equal(out[[1]]$data, prds[[4]]$data)
+
 })
 
 test_that("PipeOpWeightedMajorityVote - prob - train and predict", {
@@ -83,6 +116,21 @@ test_that("PipeOpWeightedMajorityVote - prob - train and predict", {
   out = predict_pipeop(po, prds)
   expect_class(out[[1]], "PredictionClassif")
   expect_equivalent(out[[1]], prds[[4]])
+
+
+  po = PipeOpMajorityVote$new()
+  expect_pipeop(po)
+  expect_list(train_pipeop(po, prds), len = 1)
+  out = predict_pipeop(po, prds)
+  expect_class(out[[1]], "PredictionClassif")
+
+  po = PipeOpMajorityVote$new()
+  po$weights = c(0, 0, 0, 1)
+  expect_list(train_pipeop(po, prds), len = 1)
+  out = predict_pipeop(po, prds)
+  expect_class(out[[1]], "PredictionClassif")
+  expect_equivalent(out[[1]], prds[[4]])
+
 })
 
 ## test_that("PipeOpNlOptMajorityVote - response - train and predict", {

--- a/tests/testthat/test_pipeop_unbranch.R
+++ b/tests/testthat/test_pipeop_unbranch.R
@@ -9,7 +9,10 @@ test_that("PipeOpUnbranch - basic properties", {
 
   expect_pipeop_class(PipeOpUnbranch, list(1))
   expect_pipeop_class(PipeOpUnbranch, list(3))
-  expect_error(PipeOpUnbranch$new(0))
+
+  po = PipeOpUnbranch$new()
+  expect_pipeop(po)
+  expect_data_table(po$input, nrow = 1)
 })
 
 
@@ -28,5 +31,27 @@ test_that("PipeOpUnbranch - train and predict", {
   expect_true(length(pout) == 1)
   expect_equal(pout[[1]], t2)
 
-  expect_error(ubranch$train(list(t1)))
+  expect_error(ubranch$train_internal(list(t1, t2)))
+  expect_error(ubranch$train_internal(list(t1)))
+
+  ubranch = PipeOpUnbranch$new()
+  expect_true(ubranch$innum == 1)
+
+  tout = train_pipeop(ubranch, (list(t1, NO_OP)))
+  expect_class(tout[[1]], "Task")
+  expect_true(length(tout) == 1L)
+
+  pout = predict_pipeop(ubranch, (list(NO_OP, t2)))
+  expect_true(length(pout) == 1)
+  expect_equal(pout[[1]], t2)
+
+  ubranch = PipeOpUnbranch$new()
+  tout = train_pipeop(ubranch, (list(t1)))
+  expect_class(tout[[1]], "Task")
+  expect_true(length(tout) == 1L)
+
+  pout = predict_pipeop(ubranch, (list(t2)))
+  expect_true(length(pout) == 1)
+  expect_equal(pout[[1]], t2)
+
 })

--- a/tests/testthat/test_usecases.R
+++ b/tests/testthat/test_usecases.R
@@ -95,6 +95,28 @@ test_that("branching", {
   expect_equal(names(res), "unbranch.output")
 })
 
+test_that("branching with varargs", {
+  g = PipeOpBranch$new(2L) %>>% gunion(list(PipeOpLrnRP, PipeOpLrnFL)) %>>% PipeOpUnbranch$new()
+  z = test_graph(g, n_nodes = 4L, n_edges = 4L)
+
+  expect_equal(z$g.trained$pipeops$classif.rpart$.result, list(NULL))
+  expect_equal(z$g.trained$pipeops$classif.featureless$.result, list(output = NO_OP))
+  expect_equal(z$g.trained$pipeops$unbranch$.result, list("..." = NULL))
+
+  expect_equal(z$g.predicted$pipeops$classif.rpart$.result[[1]], z$g.predicted$pipeops$unbranch$.result[[1]])
+  expect_equal(z$g.predicted$pipeops$classif.featureless$.result, list(output = NO_OP))
+
+  g = PipeOpBranch$new(2L) %>>% gunion(list(PipeOpLrnRP, PipeOpLrnFL)) %>>% PipeOpUnbranch$new()
+  task = mlr_tasks$get("iris")
+  res = g$train(task)
+  expect_true(g$is_trained)
+  expect_equal(res, list(unbranch.output = NULL))
+  res = g$predict(task)
+  expect_list(res, types = "Prediction")
+  expect_equal(names(res), "unbranch.output")
+})
+
+
 
 test_that("task chunking", {
   g = PipeOpChunk$new(2L) %>>% greplicate(PipeOpLrnRP, 2L) %>>% PipeOpMajorityVote$new(2L)


### PR DESCRIPTION
1) Instead of having to use the `PipeOpCopy` in some places, it is now possible to add multiple edges to a single output channel; outputs are then copied automatically.
    ```r
    "scale" %>>% PipeOpCopy$new(outnum = 2) %>>% gunion(list("pca", "subsample"))
    ```
    can then be written as
    ```r
    "scale" %>>% gunion(list("pca", "subsample"))
    ```
2) Instead of having to initialize some `PipeOp`s with `innum`, one could now declare one `input` channel as `vararg` by naming it `"..."`. Then multiple edges can be connected to it.
    ```r
    gunion(list("scale", "pca")) %>>% PipeOpFeatureUnion$new(innum = 2)
    ```
    can then be written as
    ```r
    gunion(list("scale", "pca")) %>>% "featureunion"
    ```
    (for this the `PipeOpFeatureUnion` needs to be adjusted to have a `"..."` input channel)