### PR TITLE
Check pipeop trained

### DIFF
--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -158,6 +158,7 @@ PipeOp = R6Class("PipeOp",
       output
     },
     predict = function(input) {
+      private$.check_trained()
       if (every(input, is_noop)) {
         return(named_list(self$output$name, NO_OP))
       }
@@ -208,7 +209,12 @@ PipeOp = R6Class("PipeOp",
 
   private = list(
     .param_set = NULL,
-    .id = NULL
+    .id = NULL,
+    .check_trained = function () {
+      if (!self$is_trained) {
+        stop("PipeOp should be trained before predicting")
+      }
+    }
   )
 )
 

--- a/tests/testthat/test_PipeOp.R
+++ b/tests/testthat/test_PipeOp.R
@@ -70,7 +70,7 @@ test_that("Errors occur for inputs", {
 
 test_that("Raises error when predicting without being trained", {
   mock_check_types = function(self, data, direction, operation) TRUE
-  local_mock(check_types = mock_check_types)
+  local_mock(check_types = mock_check_types, .env=environment(check_types))
 
   MockPipeOp = R6Class("MockPipeOp",
                          inherit = PipeOp,

--- a/tests/testthat/test_PipeOp.R
+++ b/tests/testthat/test_PipeOp.R
@@ -67,3 +67,27 @@ test_that("Errors occur for inputs", {
     po$param_set = ParamSet$new()
   }, "read-only")
 })
+
+test_that("Raises error when predicting without being trained", {
+  mock_check_types = function(self, data, direction, operation) TRUE
+  local_mock(check_types = mock_check_types)
+
+  MockPipeOp = R6Class("MockPipeOp",
+                         inherit = PipeOp,
+                         public = list(
+                           train_internal = function(input) self$state = TRUE,
+                           predict_internal = function(input) TRUE
+                         )
+                      )
+  po = MockPipeOp$new("id",
+                  input = data.table(name = "input", train = "*", predict = "*"),
+                  output = data.table(name = "output", train = "*", predict = "*")
+  )
+
+  expect_error(po$predict(list(1)), "PipeOp should be trained before predicting")
+
+  po$train(list(1))
+  expect_true(po$predict(list(1)))
+}
+
+)

--- a/tests/testthat/test_learner_weightedaverage.R
+++ b/tests/testthat/test_learner_weightedaverage.R
@@ -1,4 +1,4 @@
-context("WeighedAverage Learner")
+context("WeightedAverage Learner")
 
 test_that("LearnerClassifAvg", {
   lrn = LearnerClassifAvg$new()


### PR DESCRIPTION
This PR introduces a check for a `PipeOp` being trained before doing predictions along with a minor refactoring, and a typo fix. 