### PR TITLE
Fix graphlayout

### DIFF
--- a/R/Graph.R
+++ b/R/Graph.R
@@ -305,7 +305,7 @@ Graph = R6Class("Graph",
         p = visNetwork::visIgraphLayout(p, layout = "layout_with_sugiyama", type = "full") 
 
         # Draw edges between points
-        p = visNetwork::visEdges(p, arrows = "to", smooth = list(enabled = FALSE, forceDirection = "vertical"), length = 400)
+        p = visNetwork::visEdges(p, arrows = "to", smooth = list(enabled = FALSE, forceDirection = "vertical"))
         p 
       } else {
         suppressWarnings(plot(ig, layout = layout))  # suppress partial matching warning

--- a/R/Graph.R
+++ b/R/Graph.R
@@ -300,17 +300,12 @@ Graph = R6Class("Graph",
         ig_data$nodes$title = paste0("<p>", ig_data$nodes$title, "</p>")
         ig_data$edges$color = "lightblue"
         # Visualize the nodes
-        p = visNetwork::visNetwork(nodes = ig_data$nodes, edges = ig_data$edges)
-
-        if (any(c(duplicated(ig_data$edges$from), duplicated(ig_data$edges$to)))) {
-         # Bug in visNetwork? See: https://github.com/datastorm-open/visNetwork/issues/327
-          p = visNetwork::visIgraphLayout(p, layout = "layout_with_sugiyama", type = "full")
-        } else {
-          p = visNetwork::visIgraphLayout(p, layout = "layout_with_kk", type = "full")
-        }
+        p = visNetwork::visNetwork(nodes = ig_data$nodes, edges = ig_data$edges, height = "500px", width = "40%")
+        p = visNetwork::visIgraphLayout(p, layout = "layout_with_sugiyama", type = "full") 
 
         # Draw edges between points
-        visNetwork::visEdges(p, arrows = "to", smooth = list(enabled = FALSE, forceDirection = "vertical"))
+        p = visNetwork::visEdges(p, arrows = "to", smooth = list(enabled = FALSE, forceDirection = "vertical"), length = 400)
+        p
       } else {
         suppressWarnings(plot(ig, layout = layout))  # suppress partial matching warning
       }

--- a/R/Graph.R
+++ b/R/Graph.R
@@ -83,6 +83,7 @@
 #'   (`logical(1)`) -> `NULL` \cr
 #'   Plot the [`Graph`], using either the \pkg{igraph} package (for `html = FALSE`, default) or
 #'   the `visNetwork` package for `html = TRUE` producing a [`htmlWidget`][htmlwidgets::htmlwidgets].
+#'   The [`htmlWidget`][htmlwidgets::htmlwidgets] can be rescaled using [`visOptions`][visNetwork::visOptions].
 #' * `print()` \cr
 #'   () -> `NULL` \cr
 #'   Print a representation of the [`Graph`] on the console. Output is a table with one row for each contained [`PipeOp`] and

--- a/R/Graph.R
+++ b/R/Graph.R
@@ -300,12 +300,12 @@ Graph = R6Class("Graph",
         ig_data$nodes$title = paste0("<p>", ig_data$nodes$title, "</p>")
         ig_data$edges$color = "lightblue"
         # Visualize the nodes
-        p = visNetwork::visNetwork(nodes = ig_data$nodes, edges = ig_data$edges, height = "500px", width = "40%")
+        p = visNetwork::visNetwork(nodes = ig_data$nodes, edges = ig_data$edges, height = "400px", width = "50%")
         p = visNetwork::visIgraphLayout(p, layout = "layout_with_sugiyama", type = "full") 
 
         # Draw edges between points
         p = visNetwork::visEdges(p, arrows = "to", smooth = list(enabled = FALSE, forceDirection = "vertical"), length = 400)
-        p
+        p 
       } else {
         suppressWarnings(plot(ig, layout = layout))  # suppress partial matching warning
       }

--- a/man/Graph.Rd
+++ b/man/Graph.Rd
@@ -92,6 +92,7 @@ are therefore unambiguous, they can be omitted (i.e. left as \code{NULL}).
 (\code{logical(1)}) -> \code{NULL} \cr
 Plot the \code{\link{Graph}}, using either the \pkg{igraph} package (for \code{html = FALSE}, default) or
 the \code{visNetwork} package for \code{html = TRUE} producing a \code{\link[htmlwidgets:htmlwidgets]{htmlWidget}}.
+The \code{\link[htmlwidgets:htmlwidgets]{htmlWidget}} can be rescaled using \code{\link[visNetwork:visOptions]{visOptions}}.
 \item \code{print()} \cr
 () -> \code{NULL} \cr
 Print a representation of the \code{\link{Graph}} on the console. Output is a table with one row for each contained \code{\link{PipeOp}} and


### PR DESCRIPTION
This should fix most of the spacing problems for simpler and more complicated graphs.
Additionally also simple graphs are now laid out using `layout_with_sugiyama`. 

Using `%>% visNetwork::visOptions(width = "400px", height = "400px")` the resulting plots can be further customized.
