### PR TITLE
First implementation of PipeOpImputeLearner

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -102,6 +102,7 @@ Collate:
     'PipeOpICA.R'
     'PipeOpImpute.R'
     'PipeOpImputeHist.R'
+    'PipeOpImputeLearner.R'
     'PipeOpImputeMean.R'
     'PipeOpImputeMedian.R'
     'PipeOpImputeNewlvl.R'

--- a/R/PipeOpImputeLearner.R
+++ b/R/PipeOpImputeLearner.R
@@ -123,4 +123,7 @@ PipeOpImputeLearner = R6Class("PipeOpImputeLearner",
                            )
 )
 
-mlr_pipeops$add("imputelearner", PipeOpImputeLearner)
+mlr_pipeops$add("imputelearner", PipeOpImputeLearner,
+                list(learner = R6Class("Learner", public = list(id = "learner",
+                                                                task_type = "regr",
+                                                                param_set = ParamSet$new()))$new()))

--- a/R/PipeOpImputeLearner.R
+++ b/R/PipeOpImputeLearner.R
@@ -1,0 +1,99 @@
+#' @title PipeOpImputeLearner
+#'
+#' @usage NULL
+#' @name mlr_pipeops_imputelearner
+#' @format [`R6Class`] object inheriting from [`PipeOpImpute`]/[`PipeOp`].
+#'
+#' @description
+#' Impute numerical features by predicted values of a learner.
+#'
+#' @section Construction:
+#' ```
+#' PipeOpImputeLearner$new(id = "imputelearner", param_vals = list())
+#' ```
+#'
+#' * `id` :: `character(1)`\cr
+#'   Identifier of resulting object, default `"imputemean"`.
+#' * `learner` :: [`Learner`][mlr3::Learner] | `character(1)`
+#'   [`Learner`][mlr3::Learner] to wrap, or a string identifying a [`Learner`][mlr3::Learner] in the [`mlr3::mlr_learners`] [`Dictionary`][mlr3misc::Dictionary].
+#' * `param_vals` :: named `list`\cr
+#'   List of hyperparameter settings, overwriting the hyperparameter settings that would otherwise be set during construction. Default `list()`.
+#'
+#' @section Input and Output Channels:
+#' Input and output channels are inherited from [`PipeOpImpute`].
+#'
+#' The output is the input [`Task`][mlr3::Task] with all affected numeric features missing values imputed by first training the provided learner and then predicting the expected value.
+#'
+#' @section State:
+#' The `$state` is a named `list` with the `$state` elements inherited from [`PipeOpImpute`].
+#'
+#' The `$state$model` is a named `list` of `numeric(n)` indicating the predicted values of the respective feature.
+#'
+#' @section Parameters:
+#' The parameters are the parameters inherited from [`PipeOpImpute`].
+#'
+#' @section Internals:
+#' Uses the `$train` and `$predict` functions of the provided learner. Features that are entirely `NA` are imputed as `0`.
+#'
+#' @section Methods:
+#' Only methods inherited from [`PipeOpImpute`]/[`PipeOp`].
+#'
+#' @examples
+#' library("mlr3")
+#'
+#' task = tsk("pima")
+#' task$missings()
+#'
+#' po = po("imputemean")
+#' new_task = po$train(list(task = task))[[1]]
+#' new_task$missings()
+#'
+#' po$state$model
+#' @family PipeOps
+#' @family Imputation PipeOps
+#' @include PipeOpImpute.R
+#' @export
+PipeOpImputeLearner = R6Class("PipeOpImputeLearner",
+                           inherit = PipeOpImpute,
+                           public = list(
+                             initialize = function(id = "imputelearner", learner, param_vals = list()) {
+                               private$.learner = as_learner(learner)$clone(deep = TRUE)  # FIXME: use `clone=TRUE` when mlr-org/mlr3#344 is fixed
+
+                               super$initialize(id, param_vals = param_vals, whole_task_dependent = TRUE)
+                             },
+
+                             select_cols = function(task) task$feature_types[get("type") %in% c("numeric", "integer"), get("id")],
+
+                             train_imputer = function(feature, type, context) {
+
+                               if (all(is.na(feature))) {
+                                 pred = rep(0, length(feature))
+                               } else {
+                                 # TODO add check for missing variables in the imputation predictors
+                                 context$impute_col = feature
+                                 task = TaskRegr$new(id = "taskimpute", backend = context, target = "impute_col")
+                                 private$.learner$train(task)
+
+                                 pred = private$.learner$predict(task)
+                               }
+
+                               if (type == "integer") {
+                                 pred = as.integer(round(pred))
+                               }
+
+                               pred
+                             },
+
+                             impute = function(feature, type, model, context) {
+                               feature[is.na(feature)] = model$response[is.na(feature)]
+                               feature
+                             }
+                           ),
+
+                           private = list(
+                             .affectcols_ps = NULL,
+                             .learner = NULL
+                           )
+)
+
+mlr_pipeops$add("imputelearner", PipeOpImputeLearner)

--- a/tests/testthat/test_dictionary.R
+++ b/tests/testthat/test_dictionary.R
@@ -12,6 +12,7 @@ test_that("Dictionary contains all PipeOps", {
     PipeOpChunk = list(outnum = 2),
     PipeOpCopy = list(outnum = 2),
     PipeOpFeatureUnion = list(innum = 2),
+    PipeOpImputeLearner = list(learner = mlr_learners$get("classif.rpart")),
     PipeOpLearner = list(learner = mlr_learners$get("classif.rpart")),
     PipeOpLearnerCV = list(learner = mlr_learners$get("classif.rpart")),
     PipeOpClassifAvg = list(innum = 2),


### PR DESCRIPTION
**Reference Issues/PRs**
Create a PipeOp for learner based imputation (#262)

**What does this implement/fix?** 
This is a first try to create an imputation `PipeOp` that uses mlr3 learners to do imputation. The class is called `PipeOpImputeLearner` and inherits from `PipeOpImpute`. 

The internal structure is inspired by `PipeOpImputeMean` and `PipeOpLearner` and can be seen as a hybrid of the two. Simlar to `PipeOpLearner`, `PipeOpImputeLearner` takes a learner as initialisation parameter. Based on the task type supported by that learner (regression or classification),  `PipeOpImputeLearner` then allows to either impute numerical or categorical features. 

As of yet, the implementation does not allow for any iteration, i.e. initialise missing values with values from the marginal distribution and then iteratively impute one column with (imputed and non-missing) values of all the other columns. Instead, either a learner that can handle missing data needs to be used (e.g. `lrn("regr.rpart"`) or only non-missing columns have to be specified as context columns (see example below).

Example:
```R
library("mlr3")
library("mlr3pipelines")

task = tsk("pima")
task$missings()
# diabetes      age  glucose  insulin     mass pedigree pregnant pressure  triceps 
#       0        0        5      374       11        0        0       35      227

# Learner that can handle missing values
po = po("imputelearner", learner = lrn("regr.rpart"))
new_task = po$train(list(task = task))[[1]]
new_task$missings()
# diabetes      age pedigree pregnant  glucose  insulin     mass pressure  triceps 
#       0        0        0        0        0        0        0        0        0 

# Learner that can't handle missing values
non_miss = task$feature_names[task$missings()[-1] == 0]
po = po("imputelearner", learner = lrn("regr.lm"), 
              param_vals = list(context_columns = selector_name(non_miss)))
new_task = po$train(list(task = task))[[1]]
new_task$missings()
# diabetes      age pedigree pregnant  glucose  insulin     mass pressure  triceps 
#       0        0        0        0        0        0        0        0        0 
```

**Other comments?**
The current implementation still has the following issues, any input welcome:
* I haven't found an easy way to impute features with exclusively missing values (compared to `PipeOpImputeMean`, where those features are imputed with `0`), as this would require a learner that always returns a constant (`0` for numbers, `missing`, `mode` or `reference category` for categorical values). Other options would be to return a `NULL` model during training and deal with this in an if-else manner in the `impute` function. Do we need to do this?
* I tried to include tests into test_pipeop_impute.R. I omitted those here, because I wasn't able to solve an issue with deep clone. The default deep clone does not seem to deep clone the `PipeOp`'s state but that is where the fitted learners are located. Any advise on how to deal with this?

Finally, some of the design choices I have made might be suboptimal. I am happy for any recommendations on how to improve those.