### PR TITLE
fix po class avg

### DIFF
--- a/R/PipeOpClassifAvg.R
+++ b/R/PipeOpClassifAvg.R
@@ -83,6 +83,9 @@ PipeOpClassifAvg = R6Class("PipeOpClassifAvg",
       }
 
       prob = response = NULL
+
+      # PredictionClassif makes sure that matrix column names and response levels are identical to levels(x$truth).
+      # We therefore only check that truth levels are identical.
       lvls = map(inputs, function(x) levels(x$truth))
       lvls = Reduce(function(x, y) if (identical(x, y)) x else FALSE, lvls)
       if (isFALSE(lvls)) {

--- a/R/PipeOpClassifAvg.R
+++ b/R/PipeOpClassifAvg.R
@@ -81,22 +81,20 @@ PipeOpClassifAvg = R6Class("PipeOpClassifAvg",
       if (!(has_probs || has_classif_response)) {
         stop("PipeOpClassifAvg input predictions had missing 'prob' and missing 'response' values. At least one of them must be given for all predictions.")
       }
+
       prob = response = NULL
+      lvls = map(inputs, function(x) levels(x$truth))
+      lvls = Reduce(function(x, y) if (identical(x, y)) x else FALSE, lvls)
+      if (isFALSE(lvls)) {
+        stop("PipeOpClassifAvg input predictions are incompatible (different levels of target variable).")
+      }
+
       if (has_probs) {
-        alllevels = colnames(inputs[[1]]$prob)
-        assert_character(alllevels, any.missing = FALSE, len = ncol(inputs[[1]]$prob))
-        matrices = map(inputs, function(x) {
-          mat = x$prob
-          assert_set_equal(alllevels, colnames(mat))
-          mat[, alllevels, drop = FALSE]
-        })
-        prob = weighted_matrix_sum(matrices, weights)
+        prob = weighted_matrix_sum(map(inputs, "prob"), weights)
       }
 
       if (has_classif_response) {
-        alllevels = levels(inputs[[1]]$response)
-        map(inputs, function(x) assert_set_equal(alllevels, levels(x$response)))
-        response = weighted_factor_mean(map(inputs, "response"), weights, alllevels)
+        response = weighted_factor_mean(map(inputs, "response"), weights, lvls)
       }
 
       PredictionClassif$new(row_ids = row_ids, truth = truth, response = response, prob = prob)

--- a/tests/testthat/helper_functions.R
+++ b/tests/testthat/helper_functions.R
@@ -448,20 +448,20 @@ make_prediction_obj_classif = function(n = 100, noise = TRUE, predict_types = "r
   seed = 1444L, nclasses = 3L) {
   if (!noise) set.seed(seed)
   response = prob = NULL
-  truth = sample(letters[seq_len(nclasses)], n, replace = TRUE)
+  lvls = letters[seq_len(nclasses)]
+  truth = sample(lvls, n, replace = TRUE)
 
   if ("prob" %in% predict_types) {
     prob = matrix(runif(n * nclasses), ncol = nclasses, nrow = n)
     prob = t(apply(prob, 1, function(x) x / sum(x)))
-    colnames(prob) = unique(truth)
+    colnames(prob) = lvls
     response = colnames(prob)[max.col(prob, ties.method = "first")]
   } else if ("response" %in% predict_types) {
     response = sample(letters[seq_len(nclasses)], n, replace = TRUE)
   }
 
-  PredictionClassif$new(row_ids = seq_len(n), truth = factor(truth, levels = letters[seq_len(nclasses)]),
-    response = factor(response, levels = letters),
-    prob = prob)
+  PredictionClassif$new(row_ids = seq_len(n), truth = factor(truth, levels = lvls),
+    response = factor(response, levels = lvls), prob = prob)
 }
 
 PipeOpLrnRP = PipeOpLearner$new(mlr_learners$get("classif.rpart"))

--- a/tests/testthat/test_pipeop_ensemble.R
+++ b/tests/testthat/test_pipeop_ensemble.R
@@ -119,7 +119,6 @@ test_that("PipeOpWeightedClassifAvg - prob - train and predict", {
   expect_class(out[[1]], "PredictionClassif")
   expect_equivalent(out[[1]], prds[[4]])
 
-
   po = PipeOpClassifAvg$new()
   expect_pipeop(po)
   expect_list(train_pipeop(po, nulls), len = 1)
@@ -132,7 +131,6 @@ test_that("PipeOpWeightedClassifAvg - prob - train and predict", {
   out = predict_pipeop(po, prds)
   expect_class(out[[1]], "PredictionClassif")
   expect_equivalent(out[[1]], prds[[4]])
-
 })
 
 ## test_that("PipeOpNlOptClassifAvg - response - train and predict", {


### PR DESCRIPTION
PredcitionClassif determines the correct order of levels based on the variable `truth`. `response` and `prob` are converted accordingly to match the levels w.r.t. the response levels or column order.