### PR TITLE
Fix imputation with missings

### DIFF
--- a/R/PipeOpMissingIndicators.R
+++ b/R/PipeOpMissingIndicators.R
@@ -97,7 +97,7 @@ PipeOpMissInd = R6Class("PipeOpMissInd",
     transform = function(task) {
       if (!length(self$state$indicand_cols)) {
         # need to handle this as special case because cbind for empty tasks is broken
-        return(task)
+        return(task$select(character(0)))
       }
       data_dummy = as.data.table(is.na(task$data(cols = self$state$indicand_cols)))
       data_dummy = switch(self$param_set$values$type,
@@ -106,6 +106,7 @@ PipeOpMissInd = R6Class("PipeOpMissInd",
         logical = data_dummy,
         stop("Invalid value of 'type' parameter"))
       colnames(data_dummy) = paste0("missing_", colnames(data_dummy))
+      browser()
       task$select(character(0))$cbind(data_dummy)
     }
   )

--- a/R/PipeOpMissingIndicators.R
+++ b/R/PipeOpMissingIndicators.R
@@ -106,7 +106,6 @@ PipeOpMissInd = R6Class("PipeOpMissInd",
         logical = data_dummy,
         stop("Invalid value of 'type' parameter"))
       colnames(data_dummy) = paste0("missing_", colnames(data_dummy))
-      browser()
       task$select(character(0))$cbind(data_dummy)
     }
   )

--- a/tests/testthat/test_pipeop_featureunion.R
+++ b/tests/testthat/test_pipeop_featureunion.R
@@ -120,12 +120,11 @@ test_that("PipeOpFeatureUnion - levels are preserved", {
   tsk2$col_info
 
   pofu = PipeOpFeatureUnion$new(2)
-
+  expect_true(!pofu$is_trained)
   pofu$train(list(tsk1, tsk2))[[1]]$col_info
-
-
+  expect_true(pofu$is_trained)
   pofu$train(list(tsk1$filter(3:5), tsk2$filter(3:5)))[[1]]$col_info
-
+  expect_true(pofu$is_trained)
 
 })
 
@@ -179,9 +178,8 @@ test_that("feature renaming", {
 
   po = PipeOpFeatureUnion$new(c("z", "a", "a"))
 
-# FIXME: this needs https://github.com/mlr-org/mlr3/issues/268
-#  expect_equal(po$train(list(task, task, PipeOpPCA$new()$train(list(task))[[1]]))[[1]]$feature_names,
-#    c(task$feature_names, paste0("a.", task$feature_names), paste0("a.PC", 1:4)))
+  expect_equal(po$train(list(task, task, PipeOpPCA$new()$train(list(task))[[1]]))[[1]]$feature_names,
+    c(task$feature_names, paste0("a.", task$feature_names), paste0("a.PC", 1:4)))
 
 })
 

--- a/tests/testthat/test_pipeop_missind.R
+++ b/tests/testthat/test_pipeop_missind.R
@@ -97,7 +97,6 @@ test_that("PipeOpMissInd", {
 
 # https://stackoverflow.com/questions/60512348/how-to-impute-data-with-mlr3-and-predict-with-na-values
 test_that("union with missing rows", {
-  library(mlr3learners)
   data("mtcars", package = "datasets")
   data = mtcars[, 1:3]
   # Train task
@@ -108,26 +107,17 @@ test_that("union with missing rows", {
 
   imp_missind = po("missind")
   imp_num =  po("imputehist", param_vals = list(affect_columns = selector_type("numeric")))
-  learner = lrn("regr.ranger")
+  learner = lrn("regr.rpart")
 
-  g1 = gunion(list(imp_num,imp_missind)) %>>%
-    po("featureunion") %>>% po(learner)
+  g1 = gunion(list(imp_num, imp_missind)) %>>% po("featureunion")
+  g1$train(task_mtcars)
+  out = g1$predict(TaskRegr$new("t2", data2, target = "mpg"))[[1]]$data()
+  assert_true(!any(is.na(out)))
 
-  gl = GraphLearner$new(g1)
-  gl$train(task_mtcars)
-  out = gl$predict_newdata(data2)
-  expect_prediction(out)
-
-
-  g2 = gunion(list(imp_missind, imp_num)) %>>%
-    po("featureunion") %>>% po(learner)
-
-  data = task_mtcars$data()[12:12,]
-  data[1:1, cyl:=NA]
-  gl = GraphLearner$new(g2)
-  gl$train(task_mtcars)
-  out = gl$predict_newdata(data2)
-  expect_prediction(out)
+  g2= gunion(list(imp_missind, imp_num)) %>>% po("featureunion")
+  g2$train(task_mtcars)
+  out = g2$predict(TaskRegr$new("t2", data2, target = "mpg"))[[1]]$data()
+  assert_true(!any(is.na(out)))
 })
 
 # https://stackoverflow.com/questions/60512348/how-to-impute-data-with-mlr3-and-predict-with-na-values


### PR DESCRIPTION
This should fix https://stackoverflow.com/questions/60512348/how-to-impute-data-with-mlr3-and-predict-with-na-values

Problem was:
`PipeOpMissInd`, when trained on a task without missing data returned the full (unchanged) task during prediction.
This led to a situation where the ordere of `PipeOp's` in `gunion` mattered, as the second task would overwrite the first one. 

This patch returns an empty task, in case no indicators are added during training.

There should be some more info that columns are overwritten in `PipeOpFeatureUnion`, will open an issue for this.
