### PR TITLE
hash only PipeOp$param_set$values

### DIFF
--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -108,8 +108,7 @@
 #'   Can be used to filter `as.data.table(mlr_pipeops)`.
 #'   PipeOp tags are inherited and child classes can introduce additional tags.
 #' * `hash` :: `character(1)` \cr
-#'   Checksum calculated on the [`PipeOp`], depending on the [`PipeOp`]'s `class` and the slots `$id` and `$param_set`
-#'   (and therefore also `$param_set$values`). If a
+#'   Checksum calculated on the [`PipeOp`], depending on the [`PipeOp`]'s `class` and the slots `$id` and `$param_set$values`. If a
 #'   [`PipeOp`]'s functionality may change depending on more than these values, it should inherit the `$hash` active
 #'   binding and calculate the hash as `digest(list(super$hash, <OTHER THINGS>), algo = "xxhash64")`.
 #' * `.result` :: `list` \cr
@@ -295,7 +294,7 @@ PipeOp = R6Class("PipeOp",
     outnum = function() nrow(self$output),
     is_trained = function() !is.null(self$state),
     hash = function() {
-      digest(list(class(self), self$id, self$param_set),
+      digest(list(class(self), self$id, self$param_set$values),
         algo = "xxhash64")
     }
   ),


### PR DESCRIPTION
found by florian:

```r
[ins] r$>   library(mlr3)

[ins] r$>   library(paradox)

[ins] r$>   library(mlr3pipelines)

[ins] r$>   library(digest)

[ins] r$>   tsk = tsk("iris")

[ins] r$>   po = po("scale")

[ins] r$>   digest(po$param_set, algo = "xxhash64")
[1] "ae9978bcbd2ae4ef"

[ins] r$>   po$hash
[1] "190e8f1cb6e2a269"

[ins] r$>   po$train(list(tsk))
$output
<TaskClassif:iris> (150 x 5)
* Target: Species
* Properties: multiclass
* Features (4):
  - dbl (4): Petal.Length, Petal.Width, Sepal.Length, Sepal.Width


[ins] r$>   digest(po$param_set, algo = "xxhash64")
[1] "984ff8482a99cd22"

[ins] r$>   po$hash
[1] "be37efcf53ed4ee9"
```