### PR TITLE
Caching Prototype

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,6 +45,7 @@ Imports:
     mlr3misc (>= 0.1.4),
     paradox,
     R6,
+    R.cache,
     withr
 Suggests:
     ggplot2,

--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -241,14 +241,13 @@ PipeOp = R6Class("PipeOp",
         return(named_list(self$output$name, NO_OP))
       }
       input = check_types(self, input, "input", "train")
-      keya <<- list(map_chr(input, get_hash), self$hash)
+      # caching
       R.cache::evalWithMemoization({
-        output = private$.train(input)
-        },
-        key = list(map_chr(input, get_hash), self$hash)
+        result = list(private$.train(input), self$state)
+        }, key = list(map_chr(input, get_hash), self$hash)
       )
-      keyb <<- list(map_chr(input, get_hash), self$hash)
-      output = check_types(self, output, "output", "train")
+      if (is.null(self$state)) state = result$state
+      output = check_types(self, result$output, "output", "train")
       output
     },
     predict = function(input) {
@@ -262,14 +261,13 @@ PipeOp = R6Class("PipeOp",
         stopf("Pipeop %s got NO_OP during train but no NO_OP during predict.", self$id)
       }
       input = check_types(self, input, "input", "predict")
-
       R.cache::evalWithMemoization({
         output = private$.predict(input)
         },
          key = list(map_chr(input, get_hash), self$hash)
       )
-      print(digest(list(class(self), self$id), algo = "xxhash64"))
-      print(digest(self$param_set, algo = "xxhash64"))
+      # print(digest(list(class(self), self$id), algo = "xxhash64"))
+      # print(digest(self$param_set, algo = "xxhash64"))
       output = check_types(self, output, "output", "predict")
       output
     }

--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -241,17 +241,13 @@ PipeOp = R6Class("PipeOp",
         return(named_list(self$output$name, NO_OP))
       }
       input = check_types(self, input, "input", "train")
-      print(self$hash)
-      print(digest(private$.param_set, algo = "xxhash64"))
-      a <<- private$.param_set
+      keya <<- list(map_chr(input, get_hash), self$hash)
       R.cache::evalWithMemoization({
         output = private$.train(input)
         },
         key = list(map_chr(input, get_hash), self$hash)
       )
-      print(self$hash)
-      print(digest(private$.param_set, algo = "xxhash64"))
-      b <<- private$.param_set
+      keyb <<- list(map_chr(input, get_hash), self$hash)
       output = check_types(self, output, "output", "train")
       output
     },

--- a/attic/caching.md
+++ b/attic/caching.md
@@ -1,0 +1,101 @@
+# Caching
+
+These docs describe `oportunistic caching`, i.e. caching after a first function call.
+If the same function is executed twice in parallel, this does not save any time/cores.
+The example currently uses the `R.cache` package by Henrik Bengtsson for caching.
+This is just a very simple caching package, that provides a clean, simple API, could
+theoretically be replaced by other packages.
+
+
+## Implementation Details
+
+Ideally we would like to do caching on an abstract level,
+perhaps within the PipeOp base-classes `$train` function.
+A very nice point would be to wrap the call to `private$.train`.
+This would make complexity very manageable.
+
+`R.cache::evalWithMemoization` memoizes the provided expression.
+The `hash` is computed from its `key` argument.
+
+
+Possible solution: adjust `PipeOp` in `PipeOp.R`
+```
+train = function(input) {
+      ...
+      t = check_types(self, input, "input", "train")
+      # caching
+      R.cache::evalWithMemoization({
+        result = list(private$.train(input), self$state) #(see A below)
+        }, key = list(map_chr(input, get_hash), self$hash)
+      )
+      if (is.null(self$state)) state = result$state #(see A below)
+      output = check_types(self, result$output, "output", "train")
+      output
+    },
+    predict = function(input) {
+      ...
+      input = check_types(self, input, "input", "predict")
+      R.cache::evalWithMemoization({
+        output = private$.predict(input)
+        },
+         key = list(map_chr(input, get_hash), self$hash)
+      )
+      output = check_types(self, output, "output", "predict")
+      output
+    }
+  ),
+```
+
+where `get_hash` is:
+```
+get_hash = function(x) {
+  if (!is.null(x$hash)) return(x$hash)
+    digest(x, algo = "xxhash64")
+}
+```
+
+## Possible problems:
+
+A) Unfortunately `private$.train()` is not a pure function, but
+   instead has side-effects:
+    - sets a `$state`
+    - ... (others?)
+
+If we can ensure that the only side-effect of `$.train` is a modified state, 
+we could also memoize the state during `$train` (see above).
+
+If other fields are updated, we need to have a list of fields that are updated or go a different route.
+
+## Further Issues:
+
+F) Should caching be optional? 
+   Probably yes!
+
+G) How do we globally enable/disable caching?
+    1. global option
+    < ugly, might not work with parallelization. >
+
+    2. caching can be turned on in `Graph` | `GraphLearner`
+    ```
+    Graph = R6Class(
+     ...
+     caching = TRUE,
+     ...
+    )
+    ```
+    `GraphLearner` gets an active binding to turn caching of it's graph on/off.
+    Could also be added as an arg to the `GraphLearner`s constructor.
+
+    The caching of individual steps is then done by adjusting calls to `graph_reduce`:
+    `graph_reduce(..., caching = self$caching)`
+
+H) Should caching be disabled for some `PipeOp`s?
+   Yes, possible solution: New field in each `PipeOp`: `cached`.
+   Caching for a pipeop only happens if `cached = TRUE`.
+   Can also be manually changed to disable caching for any pipeop.
+
+Open Questions:
+  - How do `$train` and `$predict` know whether to do caching or not?
+    Add a second argument `caching`?
+  - How do caching and `parallelization` interact?
+  - Does `R.cache::evalWithMemoization`s `key` arg need anything else?

--- a/tests/testthat/test_caching.R
+++ b/tests/testthat/test_caching.R
@@ -1,0 +1,56 @@
+context("Caching")
+
+test_that("Bagging Pipeline", {
+  library("mlr3learners")  
+  library(profvis)
+  library(ggplot2)
+
+  tsk = tsk("iris")
+  
+  po$hash
+  po$train(list(tsk))
+  po$hash
+
+  po = po("scale")
+  print(po$hash)
+  R.cache::clearCache(prompt = FALSE)
+  # R.cache::findCache(list(map(list(tsk), "hash"), po_hash))
+  po$train(list(tsk))
+  po$train(list(tsk))
+  # R.cache::findCache(list(map(list(tsk), "hash"), po_hash))
+
+  po = po("nop")
+  print(po$hash)
+  R.cache::clearCache(prompt = FALSE)
+  # R.cache::findCache(list(map(list(tsk), "hash"), po_hash))
+  po$train(list(tsk))
+  po$train(list(tsk))
+  # R.cache::findCache(list(map(list(ts
+
+  a = po("scale")
+  a$hash
+  a$param_set$values$center = FALSE
+  a$hash
+
+  for (kk in 1:5) {
+    cat(sprintf("Iteration #%d:\n", kk))
+    res <- evalWithMemoization({
+    cat("Evaluating expression...")
+    a <- 1
+    b <- 2
+    c <- 4
+    Sys.sleep(1)
+    cat("done\n")
+    b
+  })
+  print(res)
+
+  # Sanity checks
+  stopifnot(a == 1 && b == 2 && c == 4)
+
+  # Clean up
+  rm(a, b, c)
+  } # for (kk ...)
+
+})
+

--- a/tests/testthat/test_caching.R
+++ b/tests/testthat/test_caching.R
@@ -1,56 +1,91 @@
 context("Caching")
 
-test_that("Bagging Pipeline", {
-  library("mlr3learners")  
-  library(profvis)
-  library(ggplot2)
+test_that("Caching works for test hash pipeop", {
+
+  PipeOpTestHash = R6Class("PipeOpTestHash",
+    inherit = PipeOp,
+    public = list(
+      initialize = function(id = "test.hash", param_set = ParamSet$new()) {
+        super$initialize(id = id, param_set = param_set,
+          input = data.table(name = "input", train = "*", predict = "*"),
+          output = data.table(name = "output", train = "*", predict = "*")
+        )
+      }),
+    private = list(
+      .train = function(inputs) {
+        Sys.sleep(1)
+        self$state = list()
+        inputs
+      },
+      .predict = function(inputs) {
+        Sys.sleep(1)
+        inputs
+      }
+    )
+  )
+
+  # FIXME:
+  # This could fail if load is very high, nonetheless I would keep it.
 
   tsk = tsk("iris")
-  
-  po$hash
-  po$train(list(tsk))
-  po$hash
+  po = PipeOpTestHash$new()
 
-  po = po("scale")
-  print(po$hash)
+  # Takes > 1 second
   R.cache::clearCache(prompt = FALSE)
-  # R.cache::findCache(list(map(list(tsk), "hash"), po_hash))
+  st = Sys.time()
   po$train(list(tsk))
+  expect_true(st < Sys.time() - 1)
+
+  # takes < 1 second
+  st = Sys.time()
   po$train(list(tsk))
-  # R.cache::findCache(list(map(list(tsk), "hash"), po_hash))
+  expect_true(st > Sys.time() - 1)
 
-  po = po("nop")
-  print(po$hash)
-  R.cache::clearCache(prompt = FALSE)
-  # R.cache::findCache(list(map(list(tsk), "hash"), po_hash))
-  po$train(list(tsk))
-  po$train(list(tsk))
-  # R.cache::findCache(list(map(list(ts
+  # Takes > 1 second
+  st = Sys.time()
+  po$predict(list(tsk))
+  expect_true(st < Sys.time() - 1)
 
-  a = po("scale")
-  a$hash
-  a$param_set$values$center = FALSE
-  a$hash
-
-  for (kk in 1:5) {
-    cat(sprintf("Iteration #%d:\n", kk))
-    res <- evalWithMemoization({
-    cat("Evaluating expression...")
-    a <- 1
-    b <- 2
-    c <- 4
-    Sys.sleep(1)
-    cat("done\n")
-    b
-  })
-  print(res)
-
-  # Sanity checks
-  stopifnot(a == 1 && b == 2 && c == 4)
-
-  # Clean up
-  rm(a, b, c)
-  } # for (kk ...)
+  # takes < 1 second
+  st = Sys.time()
+  po$predict(list(tsk))
+  expect_true(st > Sys.time() - 1)
 
 })
 
+
+# test_that("Caching works for scale", {
+#   po = po("scale")
+#   old_hash = po$hash
+
+#   po$train(list(tsk))
+#   R.cache::saveCache(key = keya, "a")
+#   R.cache::loadCache(key = keya)
+#   R.cache::loadCache(key = keyb)
+
+#   R.cache::findCache(key = list(map(list(tsk), "hash"), po$hash))
+#   R.cache::findCache(key = list(map(list(tsk), "hash"), old_hash))
+
+#   po$train(list(tsk))
+#   # R.cache::findCache(list(map(list(tsk), "hash"), po_hash))
+
+#   tsk = tsk("zoo")
+#   print(po$hash)
+#   po$train(list(tsk))
+#   print(po$hash)
+
+
+#   po = po("nop")
+#   print(po$hash)
+#   R.cache::clearCache(prompt = FALSE)
+#   # R.cache::findCache(list(map(list(tsk), "hash"), po_hash))
+#   po$train(list(tsk))
+#   po$train(list(tsk))
+
+
+#   a = po("scale")
+#   a$hash
+#   a$param_set$values$center = FALSE
+#   a$hash
+
+# })


### PR DESCRIPTION
# Caching

These docs describe `oportunistic caching`, i.e. caching after a first function call.
If the same function is executed twice in parallel, this does not save any time/cores.
The example currently uses the `R.cache` package by Henrik Bengtsson for caching.
This is just a very simple caching package, that provides a clean, simple API, could
theoretically be replaced by other packages.


## Implementation Details

Ideally we would like to do caching on an abstract level,
perhaps within the PipeOp base-classes `$train` function.
A very nice point would be to wrap the call to `private$.train`.
This would make complexity very manageable.

`R.cache::evalWithMemoization` memoizes the provided expression.
The `hash` is computed from its `key` argument.


Possible solution: adjust `PipeOp` in `PipeOp.R`
```
train = function(input) {
      ...
      t = check_types(self, input, "input", "train")
      # caching
      R.cache::evalWithMemoization({
        result = list(private$.train(input), self$state) #(see A below)
        }, key = list(map_chr(input, get_hash), self$hash)
      )
      if (is.null(self$state)) state = result$state #(see A below)
      output = check_types(self, result$output, "output", "train")
      output
    },
    predict = function(input) {
      ...
      input = check_types(self, input, "input", "predict")
      R.cache::evalWithMemoization({
        output = private$.predict(input)
        },
         key = list(map_chr(input, get_hash), self$hash)
      )
      output = check_types(self, output, "output", "predict")
      output
    }
  ),
```

where `get_hash` is:
```
get_hash = function(x) {
  if (!is.null(x$hash)) return(x$hash)
    digest(x, algo = "xxhash64")
}
```

## Possible problems:

A) Unfortunately `private$.train()` is not a pure function, but
   instead has side-effects:
    - sets a `$state`
    - ... (others?)

If we can ensure that the only side-effect of `$.train` is a modified state, 
we could also memoize the state during `$train` (see above).

If other fields are updated, we need to have a list of fields that are updated or go a different route.

## Further Issues:

F) Should caching be optional? 
   Probably yes!

G) How do we globally enable/disable caching?
    1. global option
    < ugly, might not work with parallelization. >

    2. caching can be turned on in `Graph` | `GraphLearner`
    ```
    Graph = R6Class(
     ...
     caching = TRUE,
     ...
    )
    ```
    `GraphLearner` gets an active binding to turn caching of it's graph on/off.
    Could also be added as an arg to the `GraphLearner`s constructor.

    The caching of individual steps is then done by adjusting calls to `graph_reduce`:
    `graph_reduce(..., caching = self$caching)`

H) Should caching be disabled for some `PipeOp`s?
   Yes, possible solution: New field in each `PipeOp`: `cached`.
   Caching for a pipeop only happens if `cached = TRUE`.
   Can also be manually changed to disable caching for any pipeop.

Open Questions:
  - How do `$train` and `$predict` know whether to do caching or not?
    Add a second argument `caching`?
  - How do caching and `parallelization` interact?
  - Does `R.cache::evalWithMemoization`s `key` arg need anything else?
