### PR TITLE
add meaningful example for imputenewlvl

### DIFF
--- a/R/PipeOpImputeNewlvl.R
+++ b/R/PipeOpImputeNewlvl.R
@@ -39,13 +39,15 @@
 #' @examples
 #' library("mlr3")
 #'
-#' task = tsk("pima")
+#' data = data.table::data.table(x = factor(rep.int(c("y", "n"), times = 5)),
+#'   y = factor(c(NA, letters[2:9], NA)), z = factor(letters[1:10]))
+#' task = TaskClassif$new("task", backend = data, target = "x")
 #' task$missings()
 #'
 #' po = po("imputenewlvl")
 #' new_task = po$train(list(task = task))[[1]]
 #' new_task$missings()
-#'
+#' new_task$data()
 #' @family PipeOps
 #' @family Imputation PipeOps
 #' @include PipeOpImpute.R

--- a/man/PipeOp.Rd
+++ b/man/PipeOp.Rd
@@ -113,8 +113,7 @@ A set of tags associated with the \code{PipeOp}. Tags describe a PipeOp's purpos
 Can be used to filter \code{as.data.table(mlr_pipeops)}.
 PipeOp tags are inherited and child classes can introduce additional tags.
 \item \code{hash} :: \code{character(1)} \cr
-Checksum calculated on the \code{\link{PipeOp}}, depending on the \code{\link{PipeOp}}'s \code{class} and the slots \verb{$id} and \verb{$param_set}
-(and therefore also \verb{$param_set$values}). If a
+Checksum calculated on the \code{\link{PipeOp}}, depending on the \code{\link{PipeOp}}'s \code{class} and the slots \verb{$id} and \verb{$param_set$values}. If a
 \code{\link{PipeOp}}'s functionality may change depending on more than these values, it should inherit the \verb{$hash} active
 binding and calculate the hash as \verb{digest(list(super$hash, <OTHER THINGS>), algo = "xxhash64")}.
 \item \code{.result} :: \code{list} \cr

--- a/man/mlr_pipeops_imputenewlvl.Rd
+++ b/man/mlr_pipeops_imputenewlvl.Rd
@@ -53,13 +53,15 @@ Only methods inherited from \code{\link{PipeOpImpute}}/\code{\link{PipeOp}}.
 \examples{
 library("mlr3")
 
-task = tsk("pima")
+data = data.table::data.table(x = factor(rep.int(c("y", "n"), times = 5)),
+  y = factor(c(NA, letters[2:9], NA)), z = factor(letters[1:10]))
+task = TaskClassif$new("task", backend = data, target = "x")
 task$missings()
 
 po = po("imputenewlvl")
 new_task = po$train(list(task = task))[[1]]
 new_task$missings()
-
+new_task$data()
 }
 \seealso{
 Other PipeOps: 


### PR DESCRIPTION
closes #384 
Added toy task because now mlr_task currently has missing factors.
