### PR TITLE
PipeOpTargetTrafoSimple tests fix

### DIFF
--- a/R/PipeOpTrafo.R
+++ b/R/PipeOpTrafo.R
@@ -367,7 +367,7 @@ PipeOpTargetTrafoSimple = R6Class("PipeOpTargetTrafoSimple",
     inverter = function(prediction, predict_phase_control) {
       # FIXME: probably should only work for predict_type = "response" and needs a check here?
       #assert_string(prediction$predict_types, pattern = "response")
-      # handle predict_phase_control = identity separetely
+      # handle predict_phase_control = identity separately
       if (identical(predict_phase_control, identity)) {
         return(prediction)  # early exit
       }
@@ -416,7 +416,7 @@ mlr_pipeops$add("targettrafosimple", PipeOpTargetTrafoSimple)
 #'
 #' @section Parameters:
 #' The parameters are the parameters inherited from [`PipeOpTargetTrafo`], as well as:
-#' * `lower`  :: `numeric(1)` \cr
+#' * `lower` :: `numeric(1)` \cr
 #'   Target value of smallest item of input target. Default is 0.
 #' * `upper` :: `numeric(1)` \cr
 #'   Target value of greatest item of input target. Default is 1.

--- a/man/mlr_pipeops_targettrafoscalerange.Rd
+++ b/man/mlr_pipeops_targettrafoscalerange.Rd
@@ -42,7 +42,7 @@ The \verb{$state} is a named \code{list} with a vector of the two transformation
 
 The parameters are the parameters inherited from \code{\link{PipeOpTargetTrafo}}, as well as:
 \itemize{
-\item \code{lower}  :: \code{numeric(1)} \cr
+\item \code{lower} :: \code{numeric(1)} \cr
 Target value of smallest item of input target. Default is 0.
 \item \code{upper} :: \code{numeric(1)} \cr
 Target value of greatest item of input target. Default is 1.

--- a/man/mlr_pipeops_updatetarget.Rd
+++ b/man/mlr_pipeops_updatetarget.Rd
@@ -17,6 +17,10 @@ In case target after the \code{trafo} is a factor, levels are saved to \verb{$st
 During prediction: Sets all target values to \code{NA} before calling the \code{trafo} again.
 In case target after the \code{trafo} is a factor, levels saved in the \code{state} are
 set during prediction.
+
+As a special case when \code{trafo} is \code{identity} and \code{new_target_name} matches an existing column
+name of the data of the input task, this column is set as the new target. Depending on
+\code{drop_original_target} the original target is then either dropped or added to the features.
 }
 \section{Construction}{
 \preformatted{PipeOpUpdateTarget$new(id, param_set = ParamSet$new(),
@@ -40,21 +44,20 @@ The parameters are the parameters inherited from \code{\link{PipeOpTargetTrafo}}
 Transformation function for the target. Should only be a function of the target, i.e., taking a
 single argument. Default is \code{identity}.
 Note, that the data passed on to the target is a \code{data.table} consisting of all target column.
-\item \code{new_target_name} :: \code{character}\cr
+\item \code{new_target_name} :: \code{character(1)}\cr
 Optionally give the transformed target a new name. By default the original name is used.
 \item \code{new_task_type} :: \code{character(1)}\cr
 Optionally a new task type can be set. Legal types are listed in
 \code{mlr_reflections$task_types$type}.
-#' \code{drop_old_target} :: \code{logical(1)}\cr
+#' \code{drop_original_target} :: \code{logical(1)}\cr
 Whether to drop the original target column. Default: \code{TRUE}.
-If \code{drop_old_target}
 }
 }
 
 \section{State}{
 
 The \verb{$state} is a list of class levels for each target after trafo.
-\code{list(0)} if none of the targets have levels.
+\code{list()} if none of the targets have levels.
 }
 
 \section{Methods}{
@@ -63,12 +66,12 @@ Only methods inherited from \code{\link{PipeOp}}.
 }
 
 \examples{
-  # Create a binary class task from iris
-  library(mlr3)
-  trafo_fun = function(x) {factor(ifelse(x$Species == "setosa", "setosa", "other"))}
-  po = PipeOpUpdateTarget$new(param_vals = list(trafo = trafo_fun, new_target_name = "setosa"))
-  po$train(list(tsk("iris")))
-  po$predict(list(tsk("iris")))
+# Create a binary class task from iris
+library(mlr3)
+trafo_fun = function(x) {factor(ifelse(x$Species == "setosa", "setosa", "other"))}
+po = PipeOpUpdateTarget$new(param_vals = list(trafo = trafo_fun, new_target_name = "setosa"))
+po$train(list(tsk("iris")))
+po$predict(list(tsk("iris")))
 }
 \seealso{
 Other mlr3pipelines backend related: 

--- a/tests/testthat/test_pipeop_targettrafosimple.R
+++ b/tests/testthat/test_pipeop_targettrafosimple.R
@@ -35,12 +35,6 @@ test_that("PipeOpTargetTrafoSimple - basic properties", {
 
   expect_equal(learner$predict(task), predict_out[[1L]])
 
-  # set a new target name
-  g$pipeops$targettrafosimple$param_set$values$new_target_name = "test"
-  train_out = g$train(task)
-  expect_equal("test", g$state[[2L]]$train_task$target_names)
-  expect_true("medv" %nin% g$state[[2L]]$train_task$feature_names)
-  predict_out = g$predict(task)
 })
 
 test_that("PipeOpTargetTrafoSimple - log base 2 trafo", {

--- a/tests/testthat/test_pipeop_updatetarget.R
+++ b/tests/testthat/test_pipeop_updatetarget.R
@@ -96,3 +96,17 @@ test_that("update resample and predict_newdata", {
   g$train(t)
   g$predict_newdata(t$data(cols = t$feature_names))
 })
+
+test_that("make an existing feature a target", {
+  pom = po("update_target", new_target_name = "ash", new_task_type = "regr", drop_original_target = FALSE)
+  expect_pipeop(pom)
+  newtsk = pom$train(list(tsk("wine")))[[1]]
+  expect_task(newtsk)
+  expect_true("ash" %in% newtsk$target_names)
+  expect_true("type" %nin% newtsk$target_names)
+  expect_true("type" %in% newtsk$feature_names)
+  expect_equal(newtsk$data()$ash, tsk("wine")$data()$ash)
+
+  newtsk2 = pom$predict(list(tsk("wine")))[[1]]
+  expect_equivalent(newtsk, newtsk2)
+})


### PR DESCRIPTION
Currently `master` is broken due to the test of `PipeOpTargetTrafoSimple` where we only change the target name but keep the `identity` as the trafo/inverter function. This conflicts with the early exit handling of `PipeOpTargetTrafoSimple` and imo it is not sensible to use `PipeOpTargetTrafoSimple` if you only want to set new target names (you should use `PipeOpUpdateTarget` in this case). Therefore, I removed this test.