### PR TITLE
test for case where not all bins present in training data

### DIFF
--- a/tests/testthat/test_pipeop_histbin.R
+++ b/tests/testthat/test_pipeop_histbin.R
@@ -46,3 +46,25 @@ test_that("PipeOpHistBin - numerics out of range of training data", {
     as.logical(grep("-Inf", x[1])) && as.logical(grep("Inf", x[length(x)]))
   })))
 })
+
+test_that("PipeOpHistBin - not all bins present", {
+  task1 = mlr_tasks$get("iris")
+  dat = iris
+  dat$Sepal.Width[[1L]] = 2.13
+  task2 = TaskClassif$new("iris2", backend = dat, target = "Species")
+  
+  op = PipeOpHistBin$new(param_vals = list(breaks = seq(0, 10, by = 0.05)))
+  expect_pipeop(op)
+  
+  # task1 does not have a Sepal.Width value within the interval (2.10, 2.15]
+  bin_to_check = cut(c(2.10, 2.2), 2)[1] # (2.10, 2.15]
+  
+  result1 = op$train(list(task1))
+  expect_false(bin_to_check %in% result1[[1L]]$data()$Sepal.Width)
+  
+  result2 = op$predict(list(task2))
+  expect_true(bin_to_check %in% result2[[1L]]$data()$Sepal.Width)
+  
+  result3 = op$train(list(task2))
+  expect_equal(result2[[1L]]$data(), result3[[1L]]$data())
+})


### PR DESCRIPTION
This test is in reference to [https://github.com/mlr-org/mlr3pipelines/issues/414](https://github.com/mlr-org/mlr3pipelines/issues/414). Test this sequence of events works correctly:

1. A PipeOpHistBin is trained on Task1 , which has a value in (a,b]
2. The output from (1) does not contain (a,b]
3. The trained po is used for prediction on Task2, which has a value in (a,b]
4. The output from (3) contains (a,b]