### PR TITLE
Fix call to po() erroring

### DIFF
--- a/R/po.R
+++ b/R/po.R
@@ -30,6 +30,9 @@
 #' mlr_pipeops$get("learner", lrn("classif.rpart"),
 #'   param_vals = list(cp = 0.3))
 po = function(.obj, ...) {
+  if (missing(.obj)) {
+    return(mlr_pipeops)
+  }
   UseMethod("po")
 }
 


### PR DESCRIPTION
A call to `po()` is currently erroring (in contrast to `lrn()` or other sugar functions).