### PR TITLE
minor doc changes to targettrafos, rerun docs

### DIFF
--- a/man/PipeOpTargetTrafo.Rd
+++ b/man/PipeOpTargetTrafo.Rd
@@ -19,16 +19,18 @@ set the \verb{$state}. \code{set_state()} will be called a single time during tr
 \code{train_target()} will be called. Therefore, the \verb{$state} may contain info needed in
 \code{train_target()}.
 \item \code{train_target()} has a \code{\link[mlr3:Task]{Task}} input and should return a modified
-\code{\link[mlr3:Task]{Task}}. This typically consists of calculating a new target and modifying the
-task by using \code{private$.update_target()}. \code{train_target()} will be called during training and
-prediction because the target (and if needed also type) of the input task must be transformed
-both times.
+\code{\link[mlr3:Task]{Task}}. This typically consists of calculating a new target and modifying the task
+by using \code{private$.update_target()}, which simply calls \code{convert_task()} and drops the original
+target from the task. \code{train_target()} will be called during training and prediction because the
+target (and if needed also type) of the input task must be transformed both times.
 \item \code{train_invert()}has a \code{\link[mlr3:Task]{Task}} input and should return a \code{predict_phase_control}
-object (can be anything the user needs for the inversion later). This should not modify the input
+object (can be anything needed for the inversion later). This should not modify the input
 task.
-\item \code{inverter()} has a \code{\link[mlr3:Prediction]{Prediction}} input as well as one for a
-\code{predict_phase_control} object and should return a function that can later be used to invert the
-transformation done by \code{train_target()} and return a \code{\link[mlr3:Prediction]{Prediction}} object.
+\item \code{inverter()} takes a \code{\link[mlr3:Prediction]{Prediction}} and a \code{predict_phase_control} object as
+inputs. Here, the inverse target transformation should be applied and a
+\code{\link[mlr3:Prediction]{Prediction}} should be returned. Internally, \code{inverter()} will be wrapped to
+the \code{"fun"} output so that \code{\link{PipeOpTargetInverter}} can later dispatch the inverse target
+transformation on its \code{"prediction"} input.
 }
 }
 \section{Construction}{
@@ -75,7 +77,7 @@ The \verb{$state} is a named \code{list} and should be returned explicitly by th
 \code{private$.train()} and \code{private$.predict()} functions. These functions perform checks and go on
 to call \code{set_state()}, \code{train_target()}, \code{train_invert()} and \code{inverter()}. A subclass of
 \code{\link{PipeOpTargetTrafo}} should implement these functions and be used in combination with
-\code{\link{PipeOpTargetInverter}}.
+\code{\link{PipeOpTargetInverter}} in a \code{\link{Graph}}.
 }
 
 \section{Fields}{
@@ -101,12 +103,12 @@ return object is also \emph{not} a list but a singular \code{\link[mlr3:Task]{Ta
 (\code{\link[mlr3:Task]{Task}}) -> \code{predict_phase_control} object\cr
 Called by \code{\link{PipeOpTargetTrafo}}'s implementation of \code{private$.predict()}. Takes a single
 \code{\link[mlr3:Task]{Task}} as input and returns a \code{predict_phase_control} object (can be anything the
-user needs for the inversion later). This should not modify the input task.
+needed for the inversion later). This should not modify the input task.
 \item \code{inverter(prediction, predict_phase_control)}\cr
-(\code{\link[mlr3:Prediction]{Prediction}}, \code{predict_phase_control} object) -> \code{function}\cr
+(\code{\link[mlr3:Prediction]{Prediction}}, \code{predict_phase_control} object) -> \code{\link[mlr3:Prediction]{Prediction}}\cr
 Called by \code{private$.invert_help()} within \code{\link{PipeOpTargetTrafo}}'s implementation of
 \code{private$.predict()}. Takes a \code{\link[mlr3:Prediction]{Prediction}} and a \code{predict_phase_control}
-object as input and returns a function that can later be used for the inversion.
+object as input and returns a \code{\link[mlr3:Prediction]{Prediction}}.
 \item \code{.update_target(task, new_target, new_type = NULL, ...)}\cr
 (\code{\link[mlr3:Task]{Task}}, new_target, new_type, ...) -> \code{\link[mlr3:Task]{Task}}\cr
 Typically called within \code{train_target()}. Updates the target of a task and also the task_type

--- a/man/mlr_pipeops_imputeconstant.Rd
+++ b/man/mlr_pipeops_imputeconstant.Rd
@@ -8,8 +8,7 @@
 \code{\link{R6Class}} object inheriting from \code{\link{PipeOpImpute}}/\code{\link{PipeOp}}.
 }
 \description{
-Impute features by a constant value. To select specific features use the \code{affect_columns}
-parameter inherited from \code{\link{PipeOpImpute}}.
+Impute features by a constant value.
 }
 \section{Construction}{
 \preformatted{PipeOpImputeConstant$new(id = "imputeconstant", param_vals = list())
@@ -45,18 +44,18 @@ The parameters are the parameters inherited from \code{\link{PipeOpImpute}}, as 
 \item \code{constant} :: \code{atomic(1)}\cr
 The constant value that should be used for the imputation, atomic vector of length 1. The
 atomic mode must match the type of the features that will be selected by the \code{affect_columns}
-parameter and this will be checked during imputation. Default is \code{".MISSING"}.
+parameter and this will be checked during imputation. Initialized to \code{".MISSING"}.
 \item \code{check_levels} :: \code{logical(1)}\cr
 Should be checked whether the \code{constant} value is a valid level of factorial features (i.e., it
 already is a level)? Raises an error if unsuccesful. This check is only performed for factorial
-features (i.e., \code{factor}, \code{ordered}; skipped for \code{character}). Default is \code{TRUE}.
+features (i.e., \code{factor}, \code{ordered}; skipped for \code{character}). Initialized to \code{TRUE}.
 }
 }
 
 \section{Internals}{
 
-Adds an explicit new level to \code{factor} and \code{ordered} features, but not to \code{character} features if
-\code{check_levels} is \code{FALSE}.
+Adds an explicit new level to \code{factor} and \code{ordered} features, but not to \code{character} features,
+if \code{check_levels} is \code{FALSE} and the level is not already present.
 }
 
 \section{Methods}{
@@ -108,7 +107,7 @@ Other PipeOps:
 \code{\link{mlr_pipeops_imputemean}},
 \code{\link{mlr_pipeops_imputemedian}},
 \code{\link{mlr_pipeops_imputemode}},
-\code{\link{mlr_pipeops_imputenewlvl}},
+\code{\link{mlr_pipeops_imputeoor}},
 \code{\link{mlr_pipeops_imputesample}},
 \code{\link{mlr_pipeops_kernelpca}},
 \code{\link{mlr_pipeops_learner}},
@@ -118,8 +117,10 @@ Other PipeOps:
 \code{\link{mlr_pipeops_nop}},
 \code{\link{mlr_pipeops_pca}},
 \code{\link{mlr_pipeops_quantilebin}},
+\code{\link{mlr_pipeops_randomresponse}},
 \code{\link{mlr_pipeops_regravg}},
 \code{\link{mlr_pipeops_removeconstants}},
+\code{\link{mlr_pipeops_renamecolumns}},
 \code{\link{mlr_pipeops_scalemaxabs}},
 \code{\link{mlr_pipeops_scalerange}},
 \code{\link{mlr_pipeops_scale}},
@@ -143,7 +144,7 @@ Other Imputation PipeOps:
 \code{\link{mlr_pipeops_imputemean}},
 \code{\link{mlr_pipeops_imputemedian}},
 \code{\link{mlr_pipeops_imputemode}},
-\code{\link{mlr_pipeops_imputenewlvl}},
+\code{\link{mlr_pipeops_imputeoor}},
 \code{\link{mlr_pipeops_imputesample}}
 }
 \concept{Imputation PipeOps}

--- a/man/mlr_pipeops_learner.Rd
+++ b/man/mlr_pipeops_learner.Rd
@@ -18,7 +18,7 @@ into a machine learning pipeline which then can be handled as singular object fo
 and tuning.
 }
 \section{Construction}{
-\preformatted{PipeOpLearner$new(learner, id = if (is.character(learner)) learner else learner$id, param_vals = list())\\cr
+\preformatted{PipeOpLearner$new(learner, id = if (is.character(learner)) learner else learner$id, param_vals = list())
 }
 \itemize{
 \item \code{learner} :: \code{\link[mlr3:Learner]{Learner}} | \code{character(1)}

--- a/man/mlr_pipeops_learner_cv.Rd
+++ b/man/mlr_pipeops_learner_cv.Rd
@@ -76,7 +76,8 @@ The parameters are the parameters inherited from the \code{\link{PipeOpTaskPrepr
 Besides that, parameters introduced are:
 \itemize{
 \item \code{resampling.method} :: \code{character(1)}\cr
-Which resampling method do we want to use. Currently only supports \code{"cv"} and \code{"insample"}.
+Which resampling method do we want to use. Currently only supports \code{"cv"} and \code{"insample"}. \code{"insample"} generates
+predictions with the model trained on all training data.
 \item \code{resampling.folds} :: \code{numeric(1)}\cr
 Number of cross validation folds. Initialized to 3. Only used for \code{resampling.method = "cv"}.
 \item \code{keep_response} :: \code{logical(1)}\cr

--- a/man/mlr_pipeops_mutate.Rd
+++ b/man/mlr_pipeops_mutate.Rd
@@ -39,23 +39,22 @@ The \verb{$state} is a named \code{list} with the \verb{$state} elements inherit
 The parameters are the parameters inherited from \code{\link{PipeOpTaskPreproc}}, as well as:
 \itemize{
 \item \code{mutation} :: named \code{list} of \code{formula}\cr
-Expressions for new features to create (or present features to change), in the form of
-\code{formula}.  Each element of the list is a \code{formula} with the name of the element naming the
-feature to create or change, and the formula expression determining the result. This expression
-may reference other features, as well as variables visible at the creation of the \code{formula}
-(see examples).
+Expressions for new features to create (or present features to change), in the form of \code{formula}.
+Each element of the list is a \code{formula} with the name of the element naming the feature to create or
+change, and the formula expression determining the result. This expression may reference
+other features, as well as variables visible at the creation of the \code{formula} (see examples).
 Initialized to \code{list()}.
 \item \code{delete_originals} :: \code{logical(1)} \cr
-Whether to delete original features. Even when this is \code{FALSE}, present features may still be
-overwritten. Initialized to \code{FALSE}.
+Whether to delete original features. Even when this is \code{FALSE},
+present features may still be overwritten. Initialized to \code{FALSE}.
 }
 }
 
 \section{Internals}{
 
-A \code{formula} created using the \code{~} operator always contains a reference to the \code{environment} in
-which the \code{formula} is created. This makes it possible to use variables in the \code{~}-expressions
-that both reference either column names or variable names.
+A \code{formula} created using the \code{~} operator always contains a reference to the \code{environment} in which
+the \code{formula} is created. This makes it possible to use variables in the \code{~}-expressions that both
+reference either column names or variable names.
 
 Note that the \code{formula}s in \code{mutation} are evaluated sequentially. This allows for using
 variables that were constructed during evaluation of a previous formula. However, if existing

--- a/man/mlr_pipeops_randomresponse.Rd
+++ b/man/mlr_pipeops_randomresponse.Rd
@@ -8,9 +8,12 @@
 \code{\link{R6Class}} object inheriting from \code{\link{PipeOp}}.
 }
 \description{
-During prediction generates random responses for the \code{predict_types} \code{"prob"}
-(\code{\link[mlr3:PredictionClassif]{PredictionClassif}}) or \code{"se"}
-(\code{\link[mlr3:PredictionRegr]{PredictionRegr}}). For \code{"prob"}, the responses are sampled according to
+Takes in a \code{\link[mlr3:Prediction]{Prediction}} of \code{predict_type} \code{"prob"}
+(for \code{\link[mlr3:PredictionClassif]{PredictionClassif}}) or \code{"se"}
+(for \code{\link[mlr3:PredictionRegr]{PredictionRegr}}). and generates a randomized \code{"response"}
+prediction.
+
+For \code{"prob"}, the responses are sampled according to
 the probabilities of the input \code{\link[mlr3:PredictionClassif]{PredictionClassif}}. For \code{"se"},
 responses are randomly drawn according to the \code{rdistfun} parameter (default is \code{rnorm}) by using
 the original responses of the input \code{\link[mlr3:PredictionRegr]{PredictionRegr}} as the mean and the
@@ -51,8 +54,9 @@ The \verb{$state} is left empty (\code{list()}).
 \itemize{
 \item \code{rdistfun} :: \code{function} \cr
 A function for generating random responses when the predict type is \code{"se"}. This function must
-accept the arguments \code{n} (integerish number of responses), \code{mean} (\code{numeric(1)} for the mean),
-and  \code{sd} (\code{numeric(1)} for the  standard deviation). Default is \code{rnorm}.
+accept the arguments \code{n} (integerish number of responses), \code{mean} (\code{numeric} for the mean),
+and \code{sd} (\code{numeric} for the  standard deviation), and must \emph{vectorize} over \code{mean}
+and \code{sd}. Default is \code{rnorm}.
 }
 }
 
@@ -116,11 +120,12 @@ Other PipeOps:
 \code{\link{mlr_pipeops_fixfactors}},
 \code{\link{mlr_pipeops_histbin}},
 \code{\link{mlr_pipeops_ica}},
+\code{\link{mlr_pipeops_imputeconstant}},
 \code{\link{mlr_pipeops_imputehist}},
 \code{\link{mlr_pipeops_imputemean}},
 \code{\link{mlr_pipeops_imputemedian}},
 \code{\link{mlr_pipeops_imputemode}},
-\code{\link{mlr_pipeops_imputenewlvl}},
+\code{\link{mlr_pipeops_imputeoor}},
 \code{\link{mlr_pipeops_imputesample}},
 \code{\link{mlr_pipeops_kernelpca}},
 \code{\link{mlr_pipeops_learner}},
@@ -132,6 +137,7 @@ Other PipeOps:
 \code{\link{mlr_pipeops_quantilebin}},
 \code{\link{mlr_pipeops_regravg}},
 \code{\link{mlr_pipeops_removeconstants}},
+\code{\link{mlr_pipeops_renamecolumns}},
 \code{\link{mlr_pipeops_scalemaxabs}},
 \code{\link{mlr_pipeops_scalerange}},
 \code{\link{mlr_pipeops_scale}},

--- a/man/mlr_pipeops_renamecolumns.Rd
+++ b/man/mlr_pipeops_renamecolumns.Rd
@@ -39,8 +39,13 @@ The \verb{$state} is a named \code{list} with the \verb{$state} elements inherit
 The parameters are the parameters inherited from \code{\link{PipeOpTaskPreprocSimple}}, as well as:
 \itemize{
 \item \code{renaming} :: named \code{character}\cr
-Named character vector. The names of the vector specify the old column names that should be
-changed to the new column names as given by the elements of the vector.
+Named \code{character} vector. The names of the vector specify the old column names that should be
+changed to the new column names as given by the elements of the vector. Initialized to the empty
+character vector.
+\item \code{ignore_missing} :: \code{logical(1)}\cr
+Ignore if columns named in \code{renaming} are not found in the input \code{\link[mlr3:Task]{Task}}. If this is
+\code{FALSE}, then names found in \code{renaming} not found in the \code{\link[mlr3:Task]{Task}} cause an error.
+Initialized to \code{FALSE}.
 }
 }
 
@@ -92,11 +97,12 @@ Other PipeOps:
 \code{\link{mlr_pipeops_fixfactors}},
 \code{\link{mlr_pipeops_histbin}},
 \code{\link{mlr_pipeops_ica}},
+\code{\link{mlr_pipeops_imputeconstant}},
 \code{\link{mlr_pipeops_imputehist}},
 \code{\link{mlr_pipeops_imputemean}},
 \code{\link{mlr_pipeops_imputemedian}},
 \code{\link{mlr_pipeops_imputemode}},
-\code{\link{mlr_pipeops_imputenewlvl}},
+\code{\link{mlr_pipeops_imputeoor}},
 \code{\link{mlr_pipeops_imputesample}},
 \code{\link{mlr_pipeops_kernelpca}},
 \code{\link{mlr_pipeops_learner}},
@@ -106,6 +112,7 @@ Other PipeOps:
 \code{\link{mlr_pipeops_nop}},
 \code{\link{mlr_pipeops_pca}},
 \code{\link{mlr_pipeops_quantilebin}},
+\code{\link{mlr_pipeops_randomresponse}},
 \code{\link{mlr_pipeops_regravg}},
 \code{\link{mlr_pipeops_removeconstants}},
 \code{\link{mlr_pipeops_scalemaxabs}},

--- a/man/mlr_pipeops_scale.Rd
+++ b/man/mlr_pipeops_scale.Rd
@@ -37,10 +37,11 @@ The output is the input \code{\link[mlr3:Task]{Task}} with all affected numeric 
 The \verb{$state} is a named \code{list} with the \verb{$state} elements inherited from \code{\link{PipeOpTaskPreproc}}, as well as:
 \itemize{
 \item \code{center} :: \code{numeric}\cr
-The mean of each numeric feature during training, or 0 if \code{center} is \code{FALSE}. Will be subtracted during the predict phase.
+The mean / median (depending on \code{robust}) of each numeric feature during training, or 0 if \code{center} is \code{FALSE}. Will be subtracted during the predict phase.
 \item \code{scale} :: \code{numeric}\cr
-The root mean square, defined as \code{sqrt(sum(x^2)/(length(x)-1))}, of each feature during training, or 1 if \code{scale} is FALSE.
-During predict phase, features are divided by this.\cr
+The value by which features are divided. 1 if \code{scale} is \code{FALSE}\cr
+If \code{robust} is \code{FALSE}, this is the root mean square, defined as \code{sqrt(sum(x^2)/(length(x)-1))}, of each feature, possibly after centering.
+If \code{robust} is \code{TRUE}, this is the mean absolute deviation multiplied by 1.4826 (see \link[stats:mad]{stats::mad} of each feature, possibly after centering.
 This is 1 for features that are constant during training if \code{center} is \code{TRUE}, to avoid division-by-zero.
 }
 }
@@ -56,7 +57,7 @@ Whether to scale features, i.e. divide them by \code{sqrt(sum(x^2)/(length(x)-1)
 \item \code{robust} :: \code{logical(1)}\cr
 Whether to use robust scaling; instead of scaling / centering with mean / standard deviation,
 median and median absolute deviation \code{\link[stats:mad]{mad}} are used.
-Defaults to \code{FALSE}.
+Initialized to \code{FALSE}.
 }
 }
 

--- a/man/mlr_pipeops_targettrafoscalerange.Rd
+++ b/man/mlr_pipeops_targettrafoscalerange.Rd
@@ -15,8 +15,7 @@ where \eqn{b} is \eqn{(upper - lower) / (max(x) - min(x))} and
 prediction.
 }
 \section{Construction}{
-\preformatted{PipeOpTargetTrafoScaleRange$new(id = "targettrafoscalerange",
-  param_vals = list())
+\preformatted{PipeOpTargetTrafoScaleRange$new(id = "targettrafoscalerange", param_vals = list())
 }
 \itemize{
 \item \code{id} :: \code{character(1)}\cr


### PR DESCRIPTION
some minor changes to the docs of targettrafo pipeops.

Also some more thoughts after writing mlr-org/mlr3gallery#57

*   `train_target()` in `PipeOpTargetTrafo` should probably be renamed to something like `transformer()` (making more clear what should happen here)

*   `PipeOpTargetTrafo` should make use/allow for overloading `task_type` so that subclasses can restrict themselves to different task types

*   to update a task with respect to the target we use `convert_task` (which we should sometime move to `mlr3` and test better); to update a prediction, users need to manually construct a new `Prediction` object because truth and response are read only. Maybe we should provide a higher level function like `convert_prediction` that allows for this more easier

* wrapping a `Graph` consisting of a `PipeOpTargetTrafo %>>% Learner %>>% PipeOpTargetInverter` in a `GraphLearner` requires to manually set the `task_type` during construction of the `GraphLearner` because guessing the type is not possible when `PipeOpTargetInverter` is last in the chain.


