### PR TITLE
Adds phase hyper-parameter to PipeOpNOP

### DIFF
--- a/R/PipeOpNOP.R
+++ b/R/PipeOpNOP.R
@@ -26,7 +26,10 @@
 #' The `$state` is left empty (`list()`).
 #'
 #' @section Parameters:
-#' [`PipeOpNOP`] has no parameters.
+#' * `phase` :: `character(1)`\cr
+#' What phase information should be pushed through the `PipeOp`. If `"train"` then in training the
+#' output is identical to input but in prediction the output is `NULL`. Analogously for `"predict"`.
+#' Default is `"both"` so objects are pushed through both training and predicting.
 #'
 #' @section Internals:
 #' [`PipeOpNOP`] is a useful "default" stand-in for a [`PipeOp`]/[`Graph`] that does nothing.

--- a/R/PipeOpNOP.R
+++ b/R/PipeOpNOP.R
@@ -60,7 +60,13 @@ PipeOpNOP = R6Class("PipeOpNOP",
   inherit = PipeOp,
   public = list(
     initialize = function(id = "nop", param_vals = list()) {
-      super$initialize(id, param_vals = param_vals,
+
+      ps = ParamSet$new(list(
+        ParamFct$new(id = "phase", default = "both", levels = c("both", "train", "predict"),
+                     tags = c("train", "predict"))
+      ))
+
+      super$initialize(id, param_set = ps, param_vals = param_vals,
         input = data.table(name = "input", train = "*", predict = "*"),
         output = data.table(name = "output", train = "*", predict = "*"),
         tags = "meta"
@@ -70,11 +76,21 @@ PipeOpNOP = R6Class("PipeOpNOP",
   private = list(
     .train = function(inputs) {
       self$state = list()
-      inputs
+      phase = self$param_set$values$phase
+      if (is.null(phase) || phase %in% c("both", "train")) {
+        return(inputs)
+      } else {
+        return(list(NULL))
+      }
     },
 
     .predict = function(inputs) {
-      inputs
+      phase = self$param_set$values$phase
+      if (is.null(phase) || phase %in% c("both", "predict")) {
+        return(inputs)
+      } else {
+        return(list(NULL))
+      }
     }
   )
 )

--- a/man/mlr_pipeops_nop.Rd
+++ b/man/mlr_pipeops_nop.Rd
@@ -36,7 +36,12 @@ The \verb{$state} is left empty (\code{list()}).
 
 \section{Parameters}{
 
-\code{\link{PipeOpNOP}} has no parameters.
+\itemize{
+\item \code{phase} :: \code{character(1)}\cr
+What phase information should be pushed through the \code{PipeOp}. If \code{"train"} then in training the
+output is identical to input but in prediction the output is \code{NULL}. Analogously for \code{"predict"}.
+Default is \code{"both"} so objects are pushed through both training and predicting.
+}
 }
 
 \section{Internals}{


### PR DESCRIPTION
The purpose of this is to allow control over which phases information is passed through NOP. If `train` or `both` then training returns the input, otherwise NULL. Analogously for `predict`.