### PR TITLE
Fix R6 expect_equal problems

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,7 +78,7 @@ Suggests:
 VignetteBuilder:
     knitr
 Remotes:
-    mlr-org/mlr3
+    mlr-org/mlr3@0d0ea
 ByteCompile: true
 Encoding: UTF-8
 LazyData: true

--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -294,8 +294,19 @@ PipeOp = R6Class("PipeOp",
     outnum = function() nrow(self$output),
     is_trained = function() !is.null(self$state),
     hash = function() {
-      digest(list(class(self), self$id, self$param_set$values),
-        algo = "xxhash64")
+      digest(list(class(self), self$id, lapply(self$param_set$values, function(val) {
+        # ideally we would just want to hash `param_set$values`, but one of the values
+        # could be an R6 object with a `$hash` slot as well, in which case we take that
+        # slot's value. This is to avoid different hashes from essentially the same
+        # objects.
+        # In the following we also avoid accessing `val$hash` twice, because it could
+        # potentially be an expensive AB.
+        if (is.environment(val) && !is.null({vhash = val$hash})) {
+          vhash
+        } else {
+          val
+        }
+      })), algo = "xxhash64")
     }
   ),
 

--- a/tests/testthat/test_dictionary.R
+++ b/tests/testthat/test_dictionary.R
@@ -80,14 +80,14 @@ test_that("Dictionary contains all PipeOps", {
     }
 
     # check that mlr_pipeops$get() gives the same object as PipeOpXXX$new() does
-    expect_equal(do.call(mlr_pipeops$get, c(list(dictname), args)), test_obj)
+    expect_equal(do.call(mlr_pipeops$get, c(list(dictname), args)), test_obj, info = dictname)
 
     # check that ID can be changed
     args$id = "TESTID"
     expect_false(isTRUE(all.equal(do.call(mlr_pipeops$get, c(list(dictname), args)), test_obj)), dictname)
     test_obj$id = "TESTID"
-    expect_equal(do.call(mlr_pipeops$get, c(list(dictname), args)), test_obj)
-    expect_equal(do.call(pogen$new, args), test_obj)
+    expect_equal(do.call(mlr_pipeops$get, c(list(dictname), args)), test_obj, info = dictname)
+    expect_equal(do.call(pogen$new, args), test_obj, info = dictname)
 
     # we now check if hyperparameters can be changed through construction
     # we do this by automatically generating a hyperparameter value that deviates from the automatically constructed one.

--- a/tests/testthat/test_pipeop_randomresponse.R
+++ b/tests/testthat/test_pipeop_randomresponse.R
@@ -45,7 +45,7 @@ test_that("train and predict", {
   expect_prediction(predict_out2[[1L]])
   expect_equal(task2$data(cols = "mpg")[[1L]], predict_out2[[1L]]$truth)
   expect_numeric(predict_out2[[1L]]$response, finite = TRUE, any.missing = FALSE)
-  expect_numeric(predict_out2[[1L]]$se, len = 0L)
+  expect_numeric(na.omit(predict_out2[[1L]]$se), len = 0L)
 
   g2$pipeops$randomresponse$param_set$values$rdistfun = function(n, mean, sd) {
     expect_equal(length(mean), n)


### PR DESCRIPTION
R devel changed how it handles `as.list(<environment>)` if the environment contains an active binding. It used to return the active binding function, but now it calls the AB and gives the value. This is especially problematic since `all.equal` (and therefore `expect_equal()`) seems to use `as.list()` internally.

Old behaviour:
```r
> cl <- R6::R6Class("test", active = list(x = function() 1))$new()
> as.list(cl)$x
function() 1
<environment: 0x55a8d4eae6e8>
 > cl <- R6::R6Class("test", active = list(x = function() runif(1)))$new()
> all.equal(cl, cl) 
[1] TRUE
```
New Behaviour:
```r
 > cl <- R6::R6Class("test", active = list(x = function() 1))$new()
> as.list(cl)$x 
[1] 1
> cl <- R6::R6Class("test", active = list(x = function() runif(1)))$new()
> all.equal(cl, cl)
[1] "Component “x”: Mean relative difference: 0.9662922"
```