### PR TITLE
autotest paramsets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # mlr3pipelines 0.3.0-9000
 
+* added an autotest for ParamSets of PipeOps: expect_valid_pipeop_param_set
+
 # mlr3pipelines 0.3.0
 
 * compatibility with mlr3 0.6

--- a/R/PipeOpEnsemble.R
+++ b/R/PipeOpEnsemble.R
@@ -141,11 +141,16 @@ PipeOpEnsemble = R6Class("PipeOpEnsemble",
 # handle function environments well.
 check_weights = function(innum) {
   if (innum == 0) {
-    function(x) assert_numeric(x, any.missing = FALSE)
+    function(x) check_numeric(x, any.missing = FALSE)
   } else {
-    function(x)
-      assert(check_numeric(x, len = innum, any.missing = FALSE),
-        check_numeric(x, len = 1, any.missing = FALSE))
+    function(x) {
+      tests = c(test_numeric(x, len = innum, any.missing = FALSE), test_numeric(x, len = 1L, any.missing = FALSE))
+      if (sum(tests) == 0L) {
+        sprintf("Must be of type 'numeric', and length 1 or %s", innum)
+      } else {
+        TRUE
+      }
+    }
   }
 }
 

--- a/R/PipeOpTextVectorizer.R
+++ b/R/PipeOpTextVectorizer.R
@@ -206,7 +206,7 @@ PipeOpTextVectorizer = R6Class("PipeOpTextVectorizer",
         ParamDbl$new("k_tf", lower = 0, upper = 1, tags = c("train", "predict", "dfm_weight")),
         ParamDbl$new("base_tf", lower = 0, default = 10, tags = c("train", "predict", "dfm_weight")),
 
-        ParamFct$new("return_type", default = "bow", levels = c("bow", "integer_sequence", "factor_sequence"), tags = c("train", "predict")),
+        ParamFct$new("return_type", levels = c("bow", "integer_sequence", "factor_sequence"), tags = c("train", "predict")),
         ParamInt$new("sequence_length", default = 0, lower = 0, upper = Inf, tags = c("train", "predict", "integer_sequence"))
       ))$
         add_dep("base_df", "scheme_df", CondAnyOf$new(c("inverse", "inversemax", "inverseprob")))$

--- a/man/Graph.Rd
+++ b/man/Graph.Rd
@@ -94,8 +94,8 @@ are therefore unambiguous, they can be omitted (i.e. left as \code{NULL}).
 \item \code{plot(html)} \cr
 (\code{logical(1)}) -> \code{NULL} \cr
 Plot the \code{\link{Graph}}, using either the \pkg{igraph} package (for \code{html = FALSE}, default) or
-the \code{visNetwork} package for \code{html = TRUE} producing a \code{\link[htmlwidgets:htmlwidgets]{htmlWidget}}.
-The \code{\link[htmlwidgets:htmlwidgets]{htmlWidget}} can be rescaled using \code{\link[visNetwork:visOptions]{visOptions}}.
+the \code{visNetwork} package for \code{html = TRUE} producing a \code{\link[htmlwidgets:htmlwidgets-package]{htmlWidget}}.
+The \code{\link[htmlwidgets:htmlwidgets-package]{htmlWidget}} can be rescaled using \code{\link[visNetwork:visOptions]{visOptions}}.
 \item \code{print(dot = FALSE, dotname = "dot", fontsize = 24L)} \cr
 (\code{logical(1)}, \code{character(1)}, \code{integer(1)}) -> \code{NULL} \cr
 Print a representation of the \code{\link{Graph}} on the console. If \code{dot} is \code{FALSE}, output is a table with one row for each contained \code{\link{PipeOp}} and

--- a/man/mlr_pipeops_histbin.Rd
+++ b/man/mlr_pipeops_histbin.Rd
@@ -49,7 +49,7 @@ Either a \code{character(1)} string naming an algorithm to compute the number of
 a \code{numeric(1)} giving the number of breaks for the histogram,
 a vector \code{numeric} giving the breakpoints between the histogram cells, or
 a \code{function} to compute the vector of breakpoints or to compute the number
-of cells. Default is algorithm \code{"Sturges"} (see \code{\link[grDevices:nclass.Sturges]{grDevices::nclass.Sturges()}}).
+of cells. Default is algorithm \code{"Sturges"} (see \code{\link[grDevices:nclass]{grDevices::nclass.Sturges()}}).
 For details see \code{\link[graphics:hist]{hist()}}.
 }
 }

--- a/man/mlr_pipeops_nmf.Rd
+++ b/man/mlr_pipeops_nmf.Rd
@@ -59,7 +59,7 @@ to use \code{mlr3}'s \code{future}-based parallelization.
 
 \section{Internals}{
 
-Uses the \code{\link[NMF:nmf]{nmf}} function as well as \code{\link[NMF:basis]{basis}}, \code{\link[NMF:coef]{coef}} and
+Uses the \code{\link[NMF:nmf]{nmf}} function as well as \code{\link[NMF:basis-coef-methods]{basis}}, \code{\link[NMF:basis-coef-methods]{coef}} and
 \code{\link[MASS:ginv]{ginv}}.
 }
 

--- a/man/mlr_pipeops_targetmutate.Rd
+++ b/man/mlr_pipeops_targetmutate.Rd
@@ -44,7 +44,7 @@ The parameters are the parameters inherited from \code{\link{PipeOpTargetTrafo}}
 Transformation function for the target. Should only be a function of the target, i.e., taking a
 single \code{data.table} argument, typically with one column. The return value is used as the new
 target of the resulting \code{\link[mlr3:Task]{Task}}. To change target names, change the column name of the data
-using e.g. \code{\link[data.table:setnames]{setnames()}}.\cr
+using e.g. \code{\link[data.table:setattr]{setnames()}}.\cr
 Note that this function also gets called during prediction and should thus gracefully handle \code{NA} values.\cr
 Initialized to \code{identity()}.
 \item \code{inverter} :: \code{function} \code{data.table} -> \code{data.table} | named \code{list}\cr

--- a/man/mlr_pipeops_tunethreshold.Rd
+++ b/man/mlr_pipeops_tunethreshold.Rd
@@ -19,7 +19,7 @@ Returns a single \code{\link[mlr3:PredictionClassif]{PredictionClassif}}.
 This PipeOp should be used in conjunction with \code{\link{PipeOpLearnerCV}} in order to
 optimize thresholds of cross-validated predictions.
 In order to optimize thresholds without cross-validation, use \code{\link{PipeOpLearnerCV}}
-in conjunction with \code{\link[mlr3:ResamplingInsample]{ResamplingInsample}}.
+in conjunction with \code{\link[mlr3:mlr_resamplings_insample]{ResamplingInsample}}.
 }
 \section{Construction}{
 \preformatted{* `PipeOpTuneThreshold$new(id = "tunethreshold", param_vals = list())` \\cr
@@ -58,7 +58,7 @@ Initialized to \code{"classif.ce"}, i.e. misclassification error.
 \item \code{optimizer} :: \code{\link[bbotk:Optimizer]{Optimizer}}|\code{character(1)}\cr
 \code{\link[bbotk:Optimizer]{Optimizer}} used to find optimal thresholds.
 If \code{character}, converts to \code{\link[bbotk:Optimizer]{Optimizer}}
-via \code{\link[bbotk:opt]{opt}}. Initialized to \code{\link[bbotk:OptimizerGenSA]{OptimizerGenSA}}.
+via \code{\link[bbotk:opt]{opt}}. Initialized to \code{\link[bbotk:mlr_optimizers_gensa]{OptimizerGenSA}}.
 \item \code{log_level} :: \code{character(1)} | \code{integer(1)}\cr
 Set a temporary log-level for \code{lgr::get_logger("bbotk")}. Initialized to: "warn".
 }

--- a/tests/testthat/helper_functions.R
+++ b/tests/testthat/helper_functions.R
@@ -113,8 +113,8 @@ expect_pipeop = function(po, check_ps_default_values = TRUE) {
 
 # autotest for the parmset of a pipeop
 # - at least one of "train" or "predict" must be in every parameter's tag
-# - custom checks of ParamUty return string on failure
-# - either default oder values are set; if both, they differ (only if check_ps_default_values = TRUE)
+# - custom_checks of ParamUty return string on failure
+# - either default or values are set; if both, they differ (only if check_ps_default_values = TRUE)
 expect_valid_pipeop_param_set = function(po, check_ps_default_values = TRUE) {
   ps = po$param_set
   expect_true(every(ps$tags, function(x) length(intersect(c("train", "predict"), x)) > 0L))

--- a/tests/testthat/helper_functions.R
+++ b/tests/testthat/helper_functions.R
@@ -121,8 +121,7 @@ expect_valid_pipeop_param_set = function(po, check_ps_default_values = TRUE) {
 
   uties = ps$params[ps$ids("ParamUty")]
   if (length(uties)) {
-    test_value = NO_DEF  # most custom_checks should fail
-    # FIXME: be more sensitive for the default function(x) TRUE?
+    test_value = NO_DEF  # custom_checks should fail for NO_DEF
     results = map(uties, function(uty) {
       uty$custom_check(test_value)
     })

--- a/tests/testthat/helper_functions.R
+++ b/tests/testthat/helper_functions.R
@@ -107,7 +107,6 @@ expect_pipeop = function(po, check_ps_default_values = TRUE) {
   expect_names(names(po$output), permutation.of = c("name", "train", "predict"))
   expect_int(po$innum, lower = 1)
   expect_int(po$outnum, lower = 1)
-  expect_true(every(po$param_set$tags, function(x) length(intersect(c("train", "predict"), x)) > 0))
   expect_valid_pipeop_param_set(po, check_ps_default_values = check_ps_default_values)
 }
 

--- a/tests/testthat/test_pipeop_filter.R
+++ b/tests/testthat/test_pipeop_filter.R
@@ -4,10 +4,12 @@ test_that("PipeOpFilter", {
   task = mlr_tasks$get("boston_housing")
 
   expect_datapreproc_pipeop_class(PipeOpFilter,
-    list(filter = mlr3filters::FilterVariance$new(), param_vals = list(filter.frac = 0.5, na.rm = TRUE)), task = task)
+    list(filter = mlr3filters::FilterVariance$new(), param_vals = list(filter.frac = 0.5)), task = task,
+    check_ps_default_values = FALSE)
 
   expect_datapreproc_pipeop_class(PipeOpFilter,
-    list(filter = mlr3filters::FilterVariance$new(), param_vals = list(filter.frac = 0.5, na.rm = TRUE)), task = mlr_tasks$get("iris"))
+    list(filter = mlr3filters::FilterVariance$new(), param_vals = list(filter.frac = 0.5)), task = mlr_tasks$get("iris"),
+    check_ps_default_values = FALSE)
 
   po = PipeOpFilter$new(mlr3filters::FilterVariance$new())
 

--- a/tests/testthat/test_pipeop_histbin.R
+++ b/tests/testthat/test_pipeop_histbin.R
@@ -52,19 +52,19 @@ test_that("PipeOpHistBin - not all bins present", {
   dat = iris
   dat$Sepal.Width[[1L]] = 2.13
   task2 = TaskClassif$new("iris2", backend = dat, target = "Species")
-  
+
   op = PipeOpHistBin$new(param_vals = list(breaks = seq(0, 10, by = 0.05)))
   expect_pipeop(op)
-  
+
   # task1 does not have a Sepal.Width value within the interval (2.10, 2.15]
   bin_to_check = cut(c(2.10, 2.2), 2)[1] # (2.10, 2.15]
-  
+
   result1 = op$train(list(task1))
   expect_false(bin_to_check %in% result1[[1L]]$data()$Sepal.Width)
-  
+
   result2 = op$predict(list(task2))
   expect_true(bin_to_check %in% result2[[1L]]$data()$Sepal.Width)
-  
+
   result3 = op$train(list(task2))
   expect_equal(result2[[1L]]$data(), result3[[1L]]$data())
 })

--- a/tests/testthat/test_pipeop_ica.R
+++ b/tests/testthat/test_pipeop_ica.R
@@ -37,7 +37,7 @@ test_that("PipeOpICA - compare to fastICA", {
 
   # Change some parameters
   op2 = PipeOpICA$new(param_vals = list(method = "R", alpha = 2))
-  expect_pipeop(op2)
+  expect_pipeop(op2, check_ps_default_values = FALSE)
   set.seed(1234)
   result2 = op2$train(list(task))
   set.seed(1234)

--- a/tests/testthat/test_pipeop_impute.R
+++ b/tests/testthat/test_pipeop_impute.R
@@ -8,9 +8,9 @@ test_that("PipeOpImpute", {
     public = list(
       initialize = function(id = "impute", param_vals = list()) {
         ps = ParamSet$new(list(
-          ParamFct$new("method_num", levels = c("median", "mean", "mode", "sample", "hist", "oor", "constant"), default = "median", tags = c("train", "predict")),
-          ParamFct$new("method_fct", levels = c("oor", "sample", "mode", "constant"), default = "oor", tags = c("train", "predict")),
-          ParamFct$new("add_dummy", levels = c("none", "missing_train", "all"), default = "missing_train", tags = c("train", "predict")),
+          ParamFct$new("method_num", levels = c("median", "mean", "mode", "sample", "hist", "oor", "constant"), tags = c("train", "predict")),
+          ParamFct$new("method_fct", levels = c("oor", "sample", "mode", "constant"), tags = c("train", "predict")),
+          ParamFct$new("add_dummy", levels = c("none", "missing_train", "all"), tags = c("train", "predict")),
           ParamUty$new("innum", tags = c("train", "predict"))
         ))
         ps$values = list(method_num = "median", method_fct = "oor", add_dummy = "missing_train")

--- a/tests/testthat/test_pipeop_imputelearner.R
+++ b/tests/testthat/test_pipeop_imputelearner.R
@@ -44,7 +44,8 @@ test_that("PipeOpImputeLearner", {
     constargs = list("learner" = lrn("regr.rpart")),
     task = task,
     predict_rows_independent = FALSE,
-    affect_context_independent = FALSE)
+    affect_context_independent = FALSE,
+    check_ps_default_values = FALSE)
 
   mdata = data.table(
     stringsAsFactors = FALSE,
@@ -63,11 +64,13 @@ test_that("PipeOpImputeLearner", {
 
   expect_datapreproc_pipeop_class(PipeOpImputeLearner, task = task,
     affect_context_independent = FALSE, predict_rows_independent = FALSE,
-    constargs = list("learner" = lrn("regr.rpart")))
+    constargs = list("learner" = lrn("regr.rpart")),
+    check_ps_default_values = FALSE)
 
   expect_datapreproc_pipeop_class(PipeOpImputeLearner, task = task,
     affect_context_independent = FALSE, predict_rows_independent = FALSE,
-    constargs = list("learner" = lrn("classif.rpart")))
+    constargs = list("learner" = lrn("classif.rpart")),
+    check_ps_default_values = FALSE)
 })
 
 test_that("Test imputation matches, edge cases", {

--- a/tests/testthat/test_pipeop_learner.R
+++ b/tests/testthat/test_pipeop_learner.R
@@ -3,7 +3,7 @@ context("PipeOpLearner")
 test_that("PipeOpLearner - basic properties", {
   lrn = mlr_learners$get("classif.featureless")
   po = PipeOpLearner$new(lrn)
-  expect_pipeop(po)
+  expect_pipeop(po, check_ps_default_values = FALSE)
   expect_data_table(po$input, nrows = 1)
   expect_data_table(po$output, nrows = 1)
 
@@ -14,7 +14,7 @@ test_that("PipeOpLearner - basic properties", {
   result = predict_pipeop(po, list(task = task))
   expect_class(result[[1L]], "Prediction")
 
-  expect_pipeop_class(PipeOpLearner, list(lrn))
+  expect_pipeop_class(PipeOpLearner, list(lrn), check_ps_default_values = FALSE)
   expect_error(PipeOpLearner$new())
 })
 
@@ -23,7 +23,7 @@ test_that("PipeOpLearner - param_set and values", {
   po = PipeOpLearner$new(lrn)
 
   # Setting and getting pipeops works
-  expect_pipeop(po)
+  expect_pipeop(po, check_ps_default_values = FALSE)
   expect_equal(po$param_set, po$learner$param_set)
 
 

--- a/tests/testthat/test_pipeop_learnercv.R
+++ b/tests/testthat/test_pipeop_learnercv.R
@@ -3,7 +3,7 @@ context("PipeOpLearnerCV")
 test_that("PipeOpLearnerCV - basic properties", {
   lrn = mlr_learners$get("classif.featureless")
   po = PipeOpLearnerCV$new(lrn)
-  expect_pipeop(po$clone())
+  expect_pipeop(po$clone(), check_ps_default_values = FALSE)
   expect_data_table(po$input, nrows = 1)
   expect_data_table(po$output, nrows = 1)
 
@@ -29,10 +29,10 @@ test_that("PipeOpLearnerCV - basic properties", {
   lrn = mlr_learners$get("classif.featureless")
   iris_with_unambiguous_mode = mlr_tasks$get("iris")$filter(c(1:49, 52:150))  # want featureless learner without randomness
   expect_datapreproc_pipeop_class(PipeOpLearnerCV,
-    list(lrn), iris_with_unambiguous_mode, predict_like_train = FALSE, deterministic_train = FALSE)
+    list(lrn), iris_with_unambiguous_mode, predict_like_train = FALSE, deterministic_train = FALSE, check_ps_default_values = FALSE)
   # 'insample' PipeOpLearnerCV with deterministic Learner is deterministic in every regard!
   expect_datapreproc_pipeop_class(PipeOpLearnerCV,
-    list(lrn, param_vals = list(resampling.method = "insample")), iris_with_unambiguous_mode)
+    list(lrn, param_vals = list(resampling.method = "insample")), iris_with_unambiguous_mode, check_ps_default_values = FALSE)
 
   expect_error(PipeOpLearnerCV$new())
 


### PR DESCRIPTION
closes #502 

added `expect_valid_pipeop_param_set` helper_function that checks:
- at least one of `"train"` or `"predict"` must be in every parameter's `tag`
- `custom_check`s of `ParamUty` return string on failure
- either `default` or `values` are set; if both, they differ (only checked if `check_ps_default_values = TRUE`)

`expect_valid_pipeop_param_set` is run within `expect_pipeop` and therefore also within `expect_pipeop_class` and `expect_datapreproc_pipeop_class`. In all these `expect_` helpers, checking the last point can be turned off via `check_ps_default_values = FALSE` (necessary if some values are explicitly set during construction for the test that include the default or if the `ParamSet` includes an outer one from a `Learner` or `Filter` where currently `default` and `values` can both be set and the same)