### PR TITLE
open up PipeOpLearnerCV to all resampling methods

### DIFF
--- a/man/Graph.Rd
+++ b/man/Graph.Rd
@@ -94,8 +94,8 @@ are therefore unambiguous, they can be omitted (i.e. left as \code{NULL}).
 \item \code{plot(html)} \cr
 (\code{logical(1)}) -> \code{NULL} \cr
 Plot the \code{\link{Graph}}, using either the \pkg{igraph} package (for \code{html = FALSE}, default) or
-the \code{visNetwork} package for \code{html = TRUE} producing a \code{\link[htmlwidgets:htmlwidgets]{htmlWidget}}.
-The \code{\link[htmlwidgets:htmlwidgets]{htmlWidget}} can be rescaled using \code{\link[visNetwork:visOptions]{visOptions}}.
+the \code{visNetwork} package for \code{html = TRUE} producing a \code{\link[htmlwidgets:htmlwidgets-package]{htmlWidget}}.
+The \code{\link[htmlwidgets:htmlwidgets-package]{htmlWidget}} can be rescaled using \code{\link[visNetwork:visOptions]{visOptions}}.
 \item \code{print(dot = FALSE, dotname = "dot", fontsize = 24L)} \cr
 (\code{logical(1)}, \code{character(1)}, \code{integer(1)}) -> \code{NULL} \cr
 Print a representation of the \code{\link{Graph}} on the console. If \code{dot} is \code{FALSE}, output is a table with one row for each contained \code{\link{PipeOp}} and

--- a/man/mlr_pipeops_histbin.Rd
+++ b/man/mlr_pipeops_histbin.Rd
@@ -49,7 +49,7 @@ Either a \code{character(1)} string naming an algorithm to compute the number of
 a \code{numeric(1)} giving the number of breaks for the histogram,
 a vector \code{numeric} giving the breakpoints between the histogram cells, or
 a \code{function} to compute the vector of breakpoints or to compute the number
-of cells. Default is algorithm \code{"Sturges"} (see \code{\link[grDevices:nclass.Sturges]{grDevices::nclass.Sturges()}}).
+of cells. Default is algorithm \code{"Sturges"} (see \code{\link[grDevices:nclass]{grDevices::nclass.Sturges()}}).
 For details see \code{\link[graphics:hist]{hist()}}.
 }
 }

--- a/man/mlr_pipeops_learner_cv.Rd
+++ b/man/mlr_pipeops_learner_cv.Rd
@@ -10,7 +10,7 @@
 \description{
 Wraps an \code{\link[mlr3:Learner]{mlr3::Learner}} into a \code{\link{PipeOp}}.
 
-Returns cross-validated predictions during training as a \code{\link[mlr3:Task]{Task}} and stores a model of the
+Returns resampled predictions during training as a \code{\link[mlr3:Task]{Task}} and stores a model of the
 \code{\link[mlr3:Learner]{Learner}} trained on the whole data in \verb{$state}. This is used to create a similar
 \code{\link[mlr3:Task]{Task}} during prediction.
 
@@ -22,7 +22,7 @@ are \verb{<ID>.response} and \verb{<ID>.se}. \verb{<ID>} denotes the \verb{$id} 
 Inherits the \verb{$param_set} (and therefore \verb{$param_set$values}) from the \code{\link[mlr3:Learner]{Learner}} it is constructed from.
 
 \code{\link{PipeOpLearnerCV}} can be used to create "stacking" or "super learning" \code{\link{Graph}}s that use the output of one \code{\link[mlr3:Learner]{Learner}}
-as feature for another \code{\link[mlr3:Learner]{Learner}}. Because the \code{\link{PipeOpLearnerCV}} erases the original input features, it is often
+as features for another \code{\link[mlr3:Learner]{Learner}}. Because the \code{\link{PipeOpLearnerCV}} erases the original input features, it is often
 useful to use \code{\link{PipeOpFeatureUnion}} to bind the prediction \code{\link[mlr3:Task]{Task}} to the original input \code{\link[mlr3:Task]{Task}}.
 }
 \section{Construction}{
@@ -30,8 +30,7 @@ useful to use \code{\link{PipeOpFeatureUnion}} to bind the prediction \code{\lin
 }
 \itemize{
 \item \code{learner} :: \code{\link[mlr3:Learner]{Learner}} \cr
-\code{\link[mlr3:Learner]{Learner}} to use for cross validation / prediction, or a string identifying a
-\code{\link[mlr3:Learner]{Learner}} in the \code{\link[mlr3:mlr_learners]{mlr3::mlr_learners}} \code{\link[mlr3misc:Dictionary]{Dictionary}}.
+\code{\link[mlr3:Learner]{Learner}} to use for resampling / prediction.
 \item \code{id} :: \code{character(1)}
 Identifier of the resulting object, internally defaulting to the \code{id} of the \code{\link[mlr3:Learner]{Learner}} being wrapped.
 \item \code{param_vals} :: named \code{list}\cr
@@ -48,7 +47,7 @@ type given to \code{learner} during construction; both during training and predi
 type given to \code{learner} during construction; both during training and prediction.
 
 The output is a task with the same target as the input task, with features replaced by predictions made by the \code{\link[mlr3:Learner]{Learner}}.
-During training, this prediction is the out-of-sample prediction made by \code{\link[mlr3:resample]{resample}}, during prediction, this is the
+During training, this prediction is the prediction made by \code{\link[mlr3:resample]{resample}}, during prediction, this is the
 ordinary prediction made on the data by a \code{\link[mlr3:Learner]{Learner}} trained on the training phase data.
 }
 
@@ -76,10 +75,24 @@ The parameters are the parameters inherited from the \code{\link{PipeOpTaskPrepr
 Besides that, parameters introduced are:
 \itemize{
 \item \code{resampling.method} :: \code{character(1)}\cr
-Which resampling method do we want to use. Currently only supports \code{"cv"} and \code{"insample"}. \code{"insample"} generates
-predictions with the model trained on all training data.
-\item \code{resampling.folds} :: \code{numeric(1)}\cr
-Number of cross validation folds. Initialized to 3. Only used for \code{resampling.method = "cv"}.
+Which resampling method to use. Supports \code{"cv"},\code{"bootstrap"}, \code{"holdout"}, \code{"loo"}, \code{"repeated_cv"}, \code{"subsampling"}, \code{"custom"} and \code{"insample"}.
+See \code{\link[mlr3:mlr_resamplings]{mlr_resamplings}}.
+\code{"insample"} generates predictions with the model trained on all training data.
+In the case of the resampling method returing multiple predictions per row id, the predictions are aggregated via their mean
+(execpt for the \code{"response"} in the case of a \link[mlr3:TaskClassif]{classification Task} which is aggregated using the mode).
+In the case of the resampling method not returning predictions for all row ids as given in the input \code{\link[mlr3:Task]{Task}}, these predictions are added as missing.
+\item \code{resampling.repeats} :: \code{integer(1)}\cr
+Number of repetitions. Initialized to 30. Only used for \code{resampling.method = "bootstrap"}, or \code{"repeated_cv"}, or \code{"subsampling"}.
+\item \code{resampling.folds} :: \code{integer(1)}\cr
+Number of cross validation folds. Initialized to 3. Only used for \code{resampling.method = "cv"}, or \code{"repeated_cv"}.
+\item \code{resampling.ratio} :: \code{numeric(1)}\cr
+Ratio of observations to put into the training set. Initialized to 2/3. Only used for \code{resampling.method = "bootstrap"}, or \code{"holdout"} or \code{"subsampling"}.
+\item \code{resampling.custom.train_sets} :: \code{list()}\cr
+List with row ids for training, one list element per iteration. Must have the same length as \code{resampling.custom.test_sets}.
+Only used for \code{resampling.method = "custom"}.
+\item \code{resampling.custom.test_sets} :: \code{list()}\cr
+List with row ids for testing, one list element per iteration. Must have the same length as \code{resampling.custom.train_sets}.
+Only used for \code{resampling.method = "custom"}.
 \item \code{keep_response} :: \code{logical(1)}\cr
 Only effective during \code{"prob"} prediction: Whether to keep response values, if available. Initialized to \code{FALSE}.
 }

--- a/man/mlr_pipeops_nmf.Rd
+++ b/man/mlr_pipeops_nmf.Rd
@@ -59,7 +59,7 @@ to use \code{mlr3}'s \code{future}-based parallelization.
 
 \section{Internals}{
 
-Uses the \code{\link[NMF:nmf]{nmf}} function as well as \code{\link[NMF:basis]{basis}}, \code{\link[NMF:coef]{coef}} and
+Uses the \code{\link[NMF:nmf]{nmf}} function as well as \code{\link[NMF:basis-coef-methods]{basis}}, \code{\link[NMF:basis-coef-methods]{coef}} and
 \code{\link[MASS:ginv]{ginv}}.
 }
 

--- a/man/mlr_pipeops_targetmutate.Rd
+++ b/man/mlr_pipeops_targetmutate.Rd
@@ -44,7 +44,7 @@ The parameters are the parameters inherited from \code{\link{PipeOpTargetTrafo}}
 Transformation function for the target. Should only be a function of the target, i.e., taking a
 single \code{data.table} argument, typically with one column. The return value is used as the new
 target of the resulting \code{\link[mlr3:Task]{Task}}. To change target names, change the column name of the data
-using e.g. \code{\link[data.table:setnames]{setnames()}}.\cr
+using e.g. \code{\link[data.table:setattr]{setnames()}}.\cr
 Note that this function also gets called during prediction and should thus gracefully handle \code{NA} values.\cr
 Initialized to \code{identity()}.
 \item \code{inverter} :: \code{function} \code{data.table} -> \code{data.table} | named \code{list}\cr

--- a/man/mlr_pipeops_tunethreshold.Rd
+++ b/man/mlr_pipeops_tunethreshold.Rd
@@ -19,7 +19,7 @@ Returns a single \code{\link[mlr3:PredictionClassif]{PredictionClassif}}.
 This PipeOp should be used in conjunction with \code{\link{PipeOpLearnerCV}} in order to
 optimize thresholds of cross-validated predictions.
 In order to optimize thresholds without cross-validation, use \code{\link{PipeOpLearnerCV}}
-in conjunction with \code{\link[mlr3:ResamplingInsample]{ResamplingInsample}}.
+in conjunction with \code{\link[mlr3:mlr_resamplings_insample]{ResamplingInsample}}.
 }
 \section{Construction}{
 \preformatted{* `PipeOpTuneThreshold$new(id = "tunethreshold", param_vals = list())` \\cr
@@ -58,7 +58,7 @@ Initialized to \code{"classif.ce"}, i.e. misclassification error.
 \item \code{optimizer} :: \code{\link[bbotk:Optimizer]{Optimizer}}|\code{character(1)}\cr
 \code{\link[bbotk:Optimizer]{Optimizer}} used to find optimal thresholds.
 If \code{character}, converts to \code{\link[bbotk:Optimizer]{Optimizer}}
-via \code{\link[bbotk:opt]{opt}}. Initialized to \code{\link[bbotk:OptimizerGenSA]{OptimizerGenSA}}.
+via \code{\link[bbotk:opt]{opt}}. Initialized to \code{\link[bbotk:mlr_optimizers_gensa]{OptimizerGenSA}}.
 \item \code{log_level} :: \code{character(1)} | \code{integer(1)}\cr
 Set a temporary log-level for \code{lgr::get_logger("bbotk")}. Initialized to: "warn".
 }


### PR DESCRIPTION
Allow all resamplings currently listed in `mlr_resamplings`. Closes #500 

If a resampling returns multiple predictions for a row id, then they are aggregated using the mean; if `task_type = "classif"` aggregation for `response` is done using the mode; maybe we should simply base this on the argmax of the mean aggregation of the probs instead - if available). Maybe we also should open up to custom aggregation functions that can be passed as a hyperparameter but we have to make sure that boundaries of probs etc. are respected, e.g., all aggregated probs must be within `[0, 1]` and the sum for one row id must still be `1` (or we enforce this later),

If a resampling fails to return predictions for a row id present in the input task, this row id is added with missing values.
All in all, this results in the row ids of the input task matching the row ids of the output features based on the resampled prediction.

For custom resampling, `train_sets` and `test_sets` are currently passed as `ParamUty`s `"resampling.custom.train_sets"` and `"resampling.custom.test_sets"`; not sure if this is the best way here.
