### PR TITLE
fix bug in cbind_tasks, update tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # mlr3pipelines 0.3.0-9000
+* Changed PipeOps:
+  - PipeOpFeatureUnion: Fixed a minor bug when checking for duplicates
 
 # mlr3pipelines 0.3.0
 

--- a/tests/testthat/test_pipeop_featureunion.R
+++ b/tests/testthat/test_pipeop_featureunion.R
@@ -237,3 +237,22 @@ test_that("featureunion - collect_multiplicity", {
   expect_equal(train_out[[1]]$data, tsk$data)
   expect_equal(predict_out[[1]]$data, tsk$data)
 })
+
+test_that("featureunion - cbind_tasks - duplicates", {
+  # use iris three times, but the third time with a new inprefix;
+  # first task has the same target but a single mew non-overlapping feature
+  task1 = tsk("iris")
+  task1$filter(1:10)
+  task2 = task1$clone(deep = TRUE)
+  task3 = task1$clone(deep = TRUE)
+  inputs = list(TaskClassif$new("test", backend = cbind(task1$data(cols = "Species"), x = 1:10), target = "Species"), task1, task2, task3)
+
+  output = cbind_tasks(inputs, assert_targets_equal = TRUE, inprefix = c("", "", "", "new_iris"))
+  new_iris_names = paste0("new_iris.", task1$feature_names)
+
+  expect_set_equal(output$feature_names, c("x", task1$feature_names, new_iris_names))
+  expect_equal(output$data(cols = c("Species", task1$feature_names)), task1$data())
+  expect_equal(output$data(cols = "x"), inputs[[1L]]$data(cols = "x"))
+  expect_equal(output$data(cols = "x"), inputs[[1L]]$data(cols = "x"))
+  expect_equivalent(output$data(cols = c("Species", new_iris_names)), task1$data())
+})


### PR DESCRIPTION
somewhat related: mlr-org/mlr3gallery#77

in `cbind_tasks` explicitly return `NULL` within the for-loop before building the sum when checking for real duplicates - otherwise it may fail when tasks do not share the same features.

apparently we also no longer can rely on `task$cbind()` automatically merging duplicated columns (by their names) into a single one, therefore we have to explicitly subset to the unique feature names before cbinding to the task (otherwise it will complain - at least for a `data.table` backend)