### PR TITLE
Replace subgraph

### DIFF
--- a/R/Graph.R
+++ b/R/Graph.R
@@ -85,7 +85,7 @@
 #'   are therefore unambiguous, they can be omitted (i.e. left as `NULL`).
 #' * `replace_subgraph(ids, substitute)` \cr
 #'   (`character()`, [`Graph`] | [`PipeOp`] | [`Learner`][mlr3::Learner] | [`Filter`][mlr3filters::Filter] | `...`) -> `self` \cr
-#'   Replace a subgraph specified via ids with the substitute subgraph.
+#'   Mutates [`Graph`] by replace a subgraph specified via ids with the substitute subgraph.
 #' * `plot(html)` \cr
 #'   (`logical(1)`) -> `NULL` \cr
 #'   Plot the [`Graph`], using either the \pkg{igraph} package (for `html = FALSE`, default) or

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -36,6 +36,6 @@ register_mlr3 = function() {
 } # nocov end
 
 # static code checks should not complain about commonly used data.table columns
-utils::globalVariables(c("src_id", "dst_id", "name", "op.id", "response", "truth"))
+utils::globalVariables(c("src_id", "dst_id", "src_channel", "dst_channel", "name", "op.id", "response", "truth"))
 
 leanify_package()

--- a/man/Graph.Rd
+++ b/man/Graph.Rd
@@ -82,6 +82,10 @@ Mutates \code{\link{Graph}} by adding a \code{\link{PipeOp}} to the \code{\link{
 will not be connected within the \code{\link{Graph}} at first.\cr
 Instead of supplying a \code{\link{PipeOp}} directly, an object that can naturally be converted to a \code{\link{PipeOp}} can also
 be supplied, e.g. a \code{\link[mlr3:Learner]{Learner}} or a \code{\link[mlr3filters:Filter]{Filter}}; see \code{\link[=as_pipeop]{as_pipeop()}}.
+\item \code{remove_pipeop(id)} \cr
+(\code{character(1)}) -> \code{self} \cr
+Mutates \code{\link{Graph}} by removing the \code{\link{PipeOp}} with the matching id from the \code{\link{Graph}}.
+Corresponding edges are also removed as well as the corresponding \code{\link[paradox:ParamSet]{ParamSet}}.
 \item \code{add_edge(src_id, dst_id, src_channel = NULL, dst_channel = NULL)} \cr
 (\code{character(1)}, \code{character(1)},
 \code{character(1)} | \code{numeric(1)} | \code{NULL},
@@ -91,6 +95,9 @@ Add an edge from \code{\link{PipeOp}} \code{src_id}, and its channel \code{src_c
 channel \code{dst_channel} (identified by its name or number as listed in the \code{\link{PipeOp}}'s \verb{$input}).
 If source or destination \code{\link{PipeOp}} have only one input / output channel and \code{src_channel} / \code{dst_channel}
 are therefore unambiguous, they can be omitted (i.e. left as \code{NULL}).
+\item \code{replace_subgraph(ids, substitute)} \cr
+(\code{character()}, \code{\link{Graph}} | \code{\link{PipeOp}} | \code{\link[mlr3:Learner]{Learner}} | \code{\link[mlr3filters:Filter]{Filter}} | \code{...}) -> \code{self} \cr
+Mutates \code{\link{Graph}} by replace a subgraph specified via ids with the substitute subgraph.
 \item \code{plot(html)} \cr
 (\code{logical(1)}) -> \code{NULL} \cr
 Plot the \code{\link{Graph}}, using either the \pkg{igraph} package (for \code{html = FALSE}, default) or

--- a/man/mlr_learners_avg.Rd
+++ b/man/mlr_learners_avg.Rd
@@ -41,7 +41,7 @@ and \code{"regr.mse"}, i.e. mean squared error for regression.
 \item \code{optimizer} :: \code{\link[bbotk:Optimizer]{Optimizer}} | \code{character(1)}\cr
 \code{\link[bbotk:Optimizer]{Optimizer}} used to find optimal thresholds.
 If \code{character}, converts to \code{\link[bbotk:Optimizer]{Optimizer}}
-via \code{\link[bbotk:opt]{opt}}. Initialized to \code{\link[bbotk:OptimizerNLoptr]{OptimizerNLoptr}}.
+via \code{\link[bbotk:opt]{opt}}. Initialized to \code{\link[bbotk:mlr_optimizers_nloptr]{OptimizerNLoptr}}.
 Nloptr hyperparameters are initialized to \code{xtol_rel = 1e-8}, \code{algorithm = "NLOPT_LN_COBYLA"}
 and equal initial weights for each learner.
 For more fine-grained control, it is recommended to supply a instantiated \code{\link[bbotk:Optimizer]{Optimizer}}.

--- a/tests/testthat/test_Graph.R
+++ b/tests/testthat/test_Graph.R
@@ -4,9 +4,9 @@ test_that("linear graph", {
   g = Graph$new()
   expect_equal(g$ids(sorted = TRUE), character(0))
 
-  # FIXME: we should  "dummy" ops, so we can change properties of the ops at will
+  # FIXME: we should use "dummy" ops, so we can change properties of the ops at will
   # we should NOT use PipeOpNOP, because we want to check that $train/$predict actually does something.
-  # FIXME: we should packages of the graph
+  # FIXME: we should check packages of the graph
   op_ds = PipeOpSubsample$new()
   op_pca = PipeOpPCA$new()
   op_lrn = PipeOpLearner$new(mlr_learners$get("classif.rpart"))
@@ -427,71 +427,78 @@ test_that("dot output", {
     "nop_output\",fontsize=24]"), out[-c(1L, 15L)])
 })
 
+
+
 test_that("replace_subgraph", {
   task = tsk("iris")
 
   # Basics
   gr = Graph$new()$add_pipeop(PipeOpDebugMulti$new(2, 2))
+  address_old = address(gr)
+  gr_old = gr$clone(deep = TRUE)
   expect_error(gr$replace_subgraph("id_not_present", PipeOpDebugMulti$new(2, 2)),
     regexp = "Assertion on 'ids' failed")
   expect_error(gr$replace_subgraph("debug.multi", NULL),
     regexp = "op can not be converted to PipeOp")
-  expect_error(gr$replace_subgraph("debug.multi", PipeOpDebugMulti$new(2, 2, id = "dm1") %>>% PipeOpDebugMulti$new(2, 2, id = "dm2")),
-    regexp = "Number of ids to replace differs from the number of PipeOps in the substitute")
-  address_old = address(gr)
-  gr_old = gr$clone(deep = TRUE)
-  output = gr$replace_subgraph("debug.multi", substitute = PipeOpDebugMulti$new(2, 2))
-  expect_identical(output, gr)
+  expect_equal(gr, gr_old)  # error results in a clean reset
+  expect_true(address_old == address(gr))
+  expect_deep_clone(gr_old, gr)
+
+  gr$replace_subgraph("debug.multi", substitute = PipeOpDebugMulti$new(2, 2))
+  expect_equal(gr_old, gr)
   expect_true(address_old == address(gr))  # in place modification
   expect_deep_clone(gr_old, gr)  # replacing with exactly the same pipeop is the same as a deep clone
 
-  gr = PipeOpDebugMulti$new(2, 2, id = "dm1") %>>% PipeOpDebugMulti$new(2, 2, id = "dm2")
-  gr_old = gr$clone(deep = TRUE)
-  expect_error(gr$replace_subgraph("dm2", substitute = PipeOpDebugMulti$new(1, 2)),
-    regexp = "One of the following must apply")
-  expect_equal(gr$pipeops, gr_old$pipeops)
-  expect_equal(gr$edges, gr_old$edges)
-  expect_deep_clone(gr_old, gr)  # nothing changed due to reset
-
   # Linear Graph
   gr = po("scale") %>>% po("pca") %>>% lrn("classif.rpart")
-  gr_new = gr$clone(deep = TRUE)
-  gr_new$replace_subgraph("scale", substitute = po("scalemaxabs"))
-  expect_true(all(gr_new$ids(TRUE) == c("scalemaxabs", "pca", "classif.rpart")))
-  expect_null(gr_new$train(task)[[1L]])
-  expect_prediction_classif(gr_new$predict(task)[[1L]])
+  gr_old = gr$clone(deep = TRUE)
+  gr$replace_subgraph("scale", substitute = po("scalemaxabs"))  # replace beginning
+  expect_set_equal(gr$ids(), c("scalemaxabs", "pca", "classif.rpart"))
+  expect_true(gr$input$op.id == "scalemaxabs")
+  expect_true(gr$output$op.id == "classif.rpart")
+  expect_null(gr$train(task)[[1L]])
+  expect_prediction_classif(gr$predict(task)[[1L]])
 
-  gr_new = gr$clone(deep = TRUE)
-  gr_new$replace_subgraph(c("scale", "pca"), substitute = po("scalemaxabs") %>>% po("ica"))
-  expect_true(all(gr_new$ids(TRUE) == c("scalemaxabs", "ica", "classif.rpart")))
-  expect_null(gr_new$train(task)[[1L]])
-  expect_prediction_classif(gr_new$predict(task)[[1L]])
+  gr = gr_old$clone(deep = TRUE)
+  gr$replace_subgraph("classif.rpart", substitute = lrn("classif.featureless"))  # replace end
+  expect_set_equal(gr$ids(), c("scale", "pca", "classif.featureless"))
+  expect_true(gr$input$op.id == "scale")
+  expect_true(gr$output$op.id == "classif.featureless")
+  expect_null(gr$train(task)[[1L]])
+  expect_prediction_classif(gr$predict(task)[[1L]])
 
-  gr_new = gr$clone(deep = TRUE)
-  expect_error(gr_new$replace_subgraph(c("pca", "scale"), substitute = po("scalemaxabs") %>>% po("ica")),
-    regexp = "ids must be topologically sorted")
+  gr = gr_old$clone(deep = TRUE)
+  gr$replace_subgraph(c("scale", "pca", "classif.rpart"), substitute = po("scalemaxabs") %>>% po("ica") %>>% lrn("classif.featureless"))  # replace whole graph
+  expect_set_equal(gr$ids(), c("scalemaxabs", "ica", "classif.featureless"))
+  expect_true(gr$input$op.id == "scalemaxabs")
+  expect_true(gr$output$op.id == "classif.featureless")
+  expect_null(gr$train(task)[[1L]])
+  expect_prediction_classif(gr$predict(task)[[1L]])
+
+  gr = gr_old$clone(deep = TRUE)
+  gr$replace_subgraph(c("pca", "scale"), substitute = po("scalemaxabs") %>>% po("ica"))  # replace linear subgraph
+  expect_set_equal(gr$ids(), c("scalemaxabs", "ica", "classif.rpart"))
+  expect_true(gr$input$op.id == "scalemaxabs")
+  expect_true(gr$output$op.id == "classif.rpart")
+  expect_null(gr$train(task)[[1L]])
+  expect_prediction_classif(gr$predict(task)[[1L]])
 
   # Non linear Graph
-  gr = po("scale") %>>%
-    po("branch", c("pca", "ica")) %>>% gunion(list(po("pca"), po("ica"))) %>>% po("unbranch") %>>%
-    lrn("classif.rpart")
-  gr_new = gr$clone(deep = TRUE)
-  gr_new$replace_subgraph("ica", substitute = po("pca", id = "pca2"))
-  expect_true(all(gr_new$ids(TRUE) == c("scale", "branch", "pca", "pca2", "unbranch", "classif.rpart")))
-  expect_null(gr_new$train(task)[[1L]])
-  state1 = gr_new$state
-  gr_new$param_set$values$branch.selection = "ica"
-  expect_null(gr_new$train(task)[[1L]])
-  state2 = gr_new$state
-  expect_true(test_r6(state1$pca2, classes = "NO_OP"))
+  gr = po("scale") %>>% po("branch", c("pca", "nop")) %>>% gunion(list(po("pca"), po("nop"))) %>>% po("unbranch") %>>% lrn("classif.rpart")
+  gr_old = gr$clone(deep = TRUE)
+  expect_error(gr$replace_subgraph(c("nop"), substitute = po("ica")), regexp = "connected to a vararg channel is not supported")
+  expect_error(gr$replace_subgraph(c("branch", "pca", "nop", "unbranch"), substitute = lrn("classif.featureless")),
+    regexp = "Output type of PipeOp classif.featureless during training")
+  gr$replace_subgraph(c("branch", "pca", "nop", "unbranch"), substitute = po("branch", c("pca", "ica")) %>>% gunion(list(po("pca"), po("ica"))) %>>% po("unbranch"))
+  expect_set_equal(gr$ids(TRUE), c("scale", "branch", "pca", "ica", "unbranch", "classif.rpart"))
+  expect_true(gr$input$op.id == "scale")
+  expect_true(gr$output$op.id == "classif.rpart")
+  expect_null(gr$train(task)[[1L]])
+  state1 = gr$state
+  gr$param_set$values$branch.selection = "ica"
+  expect_null(gr$train(task)[[1L]])
+  state2 = gr$state
+  expect_true(test_r6(state1$ica, classes = "NO_OP"))
   expect_true(test_r6(state2$pca, classes = "NO_OP"))
-  expect_class(state1$pca, classes = "prcomp")
-  expect_class(state2$pca2, classes = "prcomp")
-  expect_prediction_classif(gr_new$predict(task)[[1L]])
-
-  # ppl with multiplicities
-  gr = po("scale") %>>% ppl("bagging", graph = lrn("classif.rpart"), averager = po("classifavg", collect_multiplicity = TRUE))
-  gr_new = gr$clone(deep = TRUE)
-  # FIXME:
-  gr_new$replace_subgraph("classif.rpart", substitute = lrn("classif.rpart"))
+  expect_prediction_classif(gr$predict(task)[[1L]])
 })


### PR DESCRIPTION
closes #538 
todo:

- [ ] varargs
- [ ] better docs
- [ ] more tests
- [ ] complementary function that gives us the IDs of all pipeops that are "between" two (or more) pipeops.