### PR TITLE
update docs for pipeop histbin

### DIFF
--- a/R/PipeOpHistBin.R
+++ b/R/PipeOpHistBin.R
@@ -27,12 +27,12 @@
 #'
 #' @section State:
 #' The `$state` is a named `list` with the `$state` elements inherited from [`PipeOpTaskPreproc`], as well as:
-#' * `bins` :: `list` \cr
+#' * `breaks` :: `list` \cr
 #'   List of intervals representing the bins for each numeric feature.
 #'
 #' @section Parameters:
 #' The parameters are the parameters inherited from [`PipeOpTaskPreproc`], as well as:
-#' * `bins` :: `character(1)` | `numeric` | `function` \cr
+#' * `breaks` :: `character(1)` | `numeric` | `function` \cr
 #'   Either a `character(1)` string naming an algorithm to compute the number of cells,
 #'   a `numeric(1)` giving the number of breaks for the histogram,
 #'   a vector `numeric` giving the breakpoints between the histogram cells, or
@@ -73,18 +73,18 @@ PipeOpHistBin = R6Class("PipeOpHistBin",
   private = list(
 
     .get_state_dt = function(dt, levels, target) {
-      bins = lapply(seq_col(dt), function(i) {
+      breaks = lapply(seq_col(dt), function(i) {
         breaks = invoke(graphics::hist, dt[[i]], plot = FALSE, .args = self$param_set$get_values(tags = "hist"))$breaks
         breaks[1L] = -Inf
         breaks[length(breaks)] = Inf
         breaks
       })
-      list(bins = bins)
+      list(breaks = breaks)
     },
 
     .transform_dt = function(dt, levels) {
       as.data.frame(mapply(function(d, b) ordered(cut(d, breaks = b, include.lowest = TRUE)),
-        d = dt, b = self$state$bins, SIMPLIFY = FALSE), row.names = rownames(dt))
+        d = dt, b = self$state$breaks, SIMPLIFY = FALSE), row.names = rownames(dt))
     }
   )
 )

--- a/man/mlr_pipeops_histbin.Rd
+++ b/man/mlr_pipeops_histbin.Rd
@@ -35,7 +35,7 @@ The output is the input \code{\link[mlr3:Task]{Task}} with all affected numeric 
 
 The \verb{$state} is a named \code{list} with the \verb{$state} elements inherited from \code{\link{PipeOpTaskPreproc}}, as well as:
 \itemize{
-\item \code{bins} :: \code{list} \cr
+\item \code{breaks} :: \code{list} \cr
 List of intervals representing the bins for each numeric feature.
 }
 }
@@ -44,7 +44,7 @@ List of intervals representing the bins for each numeric feature.
 
 The parameters are the parameters inherited from \code{\link{PipeOpTaskPreproc}}, as well as:
 \itemize{
-\item \code{bins} :: \code{character(1)} | \code{numeric} | \code{function} \cr
+\item \code{breaks} :: \code{character(1)} | \code{numeric} | \code{function} \cr
 Either a \code{character(1)} string naming an algorithm to compute the number of cells,
 a \code{numeric(1)} giving the number of breaks for the histogram,
 a vector \code{numeric} giving the breakpoints between the histogram cells, or


### PR DESCRIPTION
fixes #584

We called the argument `bins` while `hist()` called it `breaks`.
I think we should stick with the original names in order to avoid confusion when we want users to specify args 
that for a specific function.