### PR TITLE
Add mlr3pipelines to required packages

### DIFF
--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -227,7 +227,7 @@ PipeOp = R6Class("PipeOp",
       self$param_set$values = insert_named(self$param_set$values, param_vals)
       self$input = assert_connection_table(input)
       self$output = assert_connection_table(output)
-      self$packages = assert_character(packages, any.missing = FALSE, unique = TRUE)
+      self$packages = union("mlr3pipelines", assert_character(packages, any.missing = FALSE, min.chars = 1L))
       self$tags = assert_subset(tags, mlr_reflections$pipeops$valid_tags)
     },
 


### PR DESCRIPTION
Loaded objects from mlr3pipelines do not work without mlr3proba being installed due to the leanify() function. Usually not an issue, but we rather list all required packages to ensure a helpful error message on remote machines.