### PR TITLE
Fix fallback of predict_type in GraphLearner

### DIFF
--- a/R/GraphLearner.R
+++ b/R/GraphLearner.R
@@ -120,7 +120,7 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
           }
           task_type = get_po_task_type(graph$pipeops[[graph$rhs]])
         }
-        task_type = c(task_type, "classif")[1L]  # final fallback
+        task_type = c(task_type, "classif")[[1]]  # final fallback
       }
       assert_subset(task_type, mlr_reflections$task_types$type)
 
@@ -211,7 +211,7 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
       }
       predict_type = get_po_predict_type(self$graph$pipeops[[self$graph$rhs]])
       if (is.null(predict_type))
-        names(mlr_reflections$learner_predict_types[[self$task_type]])[1L]
+        names(mlr_reflections$learner_predict_types[[self$task_type]])[[1]]
       else
         predict_type
     },

--- a/R/GraphLearner.R
+++ b/R/GraphLearner.R
@@ -211,7 +211,7 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
       }
       predict_type = get_po_predict_type(self$graph$pipeops[[self$graph$rhs]])
       if (is.null(predict_type))
-        mlr_reflections$learner_predict_types[[self$task_type]][[1]]
+        names(mlr_reflections$learner_predict_types[[self$task_type]])[1L]
       else
         predict_type
     },


### PR DESCRIPTION
If the heuristic in `GraphLearner` cannot determine the `predict_type`, it defaults to all available predict types stored in `mlr_reflections` for the first predict type setting. In `mlr3proba` this leads to `predict_type` being a `character(4)` instead of `character(1)` which leads to further problems down the line.

```r
library(mlr3proba)
as_learner(mlr3pipelines::ppl("distrcompositor", learner = lrn("surv.coxph")))$predict_type
```

This PR fixes this behavior, setting the `predict_type` to the first predict type setting.