### PR TITLE
Fix pkgdown CI errors

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -47,17 +47,26 @@ reference:
       - PipeOpTaskPreproc
       - PipeOpTaskPreprocSimple
       - PipeOpImpute
+      - Multiplicity
   - title: Graph Tools
     contents:
       - "%>>%"
       - gunion
       - greplicate
-      - branch
   - title: PipeOps
     contents:
       - mlr_pipeops
       - po
       - starts_with("mlr_pipeops_")
+      - starts_with("PipeOp")
+  - title: Pipelines
+    contents:
+      - ppl
+      - starts_with("pipeline_")
+  - title: Graphs
+    contents:
+      - starts_with("mlr_graph")
+      - chain_graphs
   - title: Learners
     contents:
       - mlr_learners_graph
@@ -72,6 +81,8 @@ reference:
       - is_noop
       - NO_OP
       - filter_noop
+      - starts_with("as.")
+      - starts_with("is.")
   - title: Abstract PipeOps
     contents:
       - PipeOpEnsemble


### PR DESCRIPTION
pkgdown v2 errors if some topics are missing from the index. I've used best efforts to add  missing ones to matching categories.

In addition pkgdown complained about the topic `branch`. I haven't found a help page named `branch`, hence I removed it.