### PR TITLE
Fix mlr3-dev test failure: use `classif.rpart` learner `iris` dataset

### DIFF
--- a/tests/testthat/test_mlr_graphs_robustify.R
+++ b/tests/testthat/test_mlr_graphs_robustify.R
@@ -82,6 +82,7 @@ test_that("Robustify Pipeline", {
   # date features
   dat = iris
   set.seed(1)
+  lrn = lrn("classif.rpart")
   dat$date = sample(seq(as.POSIXct("2020-02-01"), to = as.POSIXct("2020-02-29"), by = "hour"),
    size = 150L)
   tsk = TaskClassif$new("iris_date", backend = dat, target = "Species")


### PR DESCRIPTION
Currently this test errors in CI (mlr3-dev). I am wondering a bit why it passed with mlr3 release but did not check in greater detail.
The current issue is that `regr.rpart` (defined a few lines above) is applied on the `iris` dataset.