### PR TITLE
Fix 642

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # mlr3pipelines 0.4.0-9000
 
-* `PipeOpLearner` `packages` slot is set to the `Learner`'s `packages`
+* `GraphLearner` can be created without cloning `Graph` (for internal use).
+* `predict.Graph` throws helpful error when it cannot create a fitting `Task`.
+* `PipeOpLearner` `packages` slot is set to the `Learner`'s `packages`.
 * Bugfix: `PipeOp` `train()` and `predict()` report correct channel name when output has wrong type.
 
 # mlr3pipelines 0.4.0

--- a/man/mlr_learners_graph.Rd
+++ b/man/mlr_learners_graph.Rd
@@ -26,7 +26,7 @@ Similarly, the predict_type of a Graph will always be the smallest denominator i
 \itemize{
 \item \code{graph} :: \code{\link{Graph}} | \code{\link{PipeOp}}\cr
 \code{\link{Graph}} to wrap. Can be a \code{\link{PipeOp}}, which is automatically converted to a \code{\link{Graph}}.
-This argument is always cloned; to access the \code{\link{Graph}} inside \code{GraphLearner} by-reference, use \verb{$graph}.\cr
+This argument is usually cloned, unless \code{clone_graph} is \code{FALSE}; to access the \code{\link{Graph}} inside \code{GraphLearner} by-reference, use \verb{$graph}.\cr
 \item \code{id} :: \code{character(1)}
 Identifier of the resulting \code{\link[mlr3:Learner]{Learner}}.
 \item \code{param_vals} :: named \code{list}\cr
@@ -35,6 +35,9 @@ List of hyperparameter settings, overwriting the hyperparameter settings . Defau
 What \code{task_type} the \code{GraphLearner} should have; usually automatically inferred for \code{\link{Graph}}s that are simple enough.
 \item \code{predict_type} :: \code{character(1)}\cr
 What \code{predict_type} the \code{GraphLearner} should have; usually automatically inferred for \code{\link{Graph}}s that are simple enough.
+\item \code{clone_graph} :: \code{logical(1)}\cr
+Whether to clone \code{graph} upon construction. Unintentionally changing \code{graph} by reference can lead to unexpected behaviour,
+so \code{TRUE} (default) is recommended.
 }
 }
 

--- a/tests/testthat/test_GraphLearner.R
+++ b/tests/testthat/test_GraphLearner.R
@@ -390,3 +390,31 @@ test_that("GraphLearner model", {
 
 
 })
+
+test_that("predict() function for Graph", {
+
+  lx = as_graph(lrn("classif.rpart"))
+
+  lx$train(tsk("iris"))
+
+  p1 = lx$pipeops$classif.rpart$learner_model$predict(tsk("iris"))
+
+  expect_equal(predict(lx, tsk("iris")), p1)
+
+  expect_error(predict(lx, iris[1:4]), "Could not create a classif-task for plain prediction data")
+
+  lx = as_graph(lrn("regr.rpart"))
+
+  lx$train(tsk("boston_housing"))
+
+  p1 = lx$pipeops$regr.rpart$learner_model$predict(tsk("boston_housing"))
+
+  expect_equal(predict(lx, tsk("boston_housing")), p1)
+
+  expect_equal(
+    predict(lx, tsk("boston_housing")$data(cols = tsk("boston_housing")$feature_names)),
+    p1$response
+  )
+
+
+})

--- a/tests/testthat/test_GraphLearner.R
+++ b/tests/testthat/test_GraphLearner.R
@@ -72,6 +72,51 @@ test_that("basic graphlearner tests", {
   expect_equal(dbmodels$task_predict$data(), scalediris$data())
 })
 
+test_that("GraphLearner clone_graph FALSE", {
+
+  # prepare graph
+  gr1 = po("pca") %>>% lrn("classif.rpart")
+  gr1$train(tsk("iris"))
+  expect_true(gr1$is_trained)
+
+  gl = GraphLearner$new(gr1, clone_graph = FALSE)
+
+  # graph is not cloned
+  expect_identical(gl$graph, gr1)
+
+  # GraphLearner$initialize resets graph state
+  expect_false(gr1$is_trained)
+
+  # compare result of training with a subset of iris
+  gl$train(tsk("iris")$filter(1:110))
+
+  # gr1 state is not set by this
+  expect_false(gr1$is_trained)
+
+  # train gr1 with a *different* task than gl
+  gr1$train(tsk("iris"))
+
+  # simulate pipeline with iris subset to get expected GraphLearner prediction result
+  pp = po("pca")
+  expected_prediction = lrn("classif.rpart")$train(pp$train(list(tsk("iris")$filter(1:110)))[[1]])$predict(pp$predict(list(tsk("iris")))[[1]])
+
+  # check that predicting on iris subset gives different result from gr1$predict()
+  expect_false(isTRUE(all.equal(gr1$predict(tsk("iris"))[[1]], expected_prediction)))
+  expect_true(gr1$is_trained)
+
+  # check that the GraphLearner predicts what we expect
+  expect_true(isTRUE(all.equal(gl$predict(tsk("iris")), expected_prediction)))
+
+  expect_false(gr1$is_trained)  # predicting with GraphLearner resets Graph state
+
+  expect_identical(gl$graph, gr1)
+
+  # check that as_learner respects `clone` now
+  gl = as_learner(gr1, clone = FALSE)
+  expect_identical(gl$graph, gr1)
+
+})
+
 test_that("graphlearner parameters behave as they should", {
   dblrn = mlr_learners$get("classif.debug")
   dblrn$param_set$values$save_tasks = TRUE


### PR DESCRIPTION
Give helpful error message in `predict.Graph`. Also allow `GraphLearner` construction without cloning `Graph`.
closes #642