### PR TITLE
start working on validation support

### DIFF
--- a/tests/testthat/test_pipeop_task_preproc.R
+++ b/tests/testthat/test_pipeop_task_preproc.R
@@ -35,3 +35,33 @@ test_that("Wrong affect_columns errors", {
   po = POPP$new("foo", param_vals = list(affect_columns = function(x) x$target_names))
   expect_error(po$train(list(tsk)), "affected_cols")
 })
+
+test_that("test roles are preprocessed", {
+  LearnerClassifTestRoles = R6Class("LearnerClassifTestRoles",
+    inherit = mlr3::LearnerClassifRpart,
+    public = list(
+      task = NULL
+    ),
+    private = list(
+      .train = function(task) {
+        self$task = task
+        super$.train(task)
+      }
+    )
+  )
+
+  graph = po("pca") %>>% LearnerClassifTestRoles$new()
+
+  task = tsk("iris")
+  split = partition(task)
+  split$test = c(split$test, split$train[1L])
+  task$row_roles$use = split$train
+  task$row_roles$test = split$test
+
+  graph$train(task)
+  outtask = graph$pipeops[[2L]]$learner$task
+
+  expect_equal(length(split$test), length(outtask$row_roles$test))
+  expect_equal(length(split$train), length(outtask$row_roles$use))
+  expect_equal(sum(lengths(outtask$row_roles)), 151)
+})


### PR DESCRIPTION
* [ ] The GraphLearner / Graph should null the test roles unless there is a PipeOp that makes use of them. Otherwise we might end up making predictions that are not needed. Maybe we want to achieve this differently / change this in `mlr3`?

PipeOps to look at: 
* [ ] PipeOpChunk
* [ ] PipeOpFeatureUnion
* [ ] PipeOpImpute
* [ ] PipeOpOVRSplit
* [x] PipeOpTuneThreshold (not really anything to do)
* [x] PipeOpLearner (not really anything to do)
* [ ] PipeOpLearnerCV (not a lot to do)
* [ ] PipeOpTrafo
* [ ] PipeOpTaskPreproc: train and predict stage now need to work a little differently even for stuff like PipeOpPreprocSimple