### PR TITLE
Correct SMOTE to only allow TaskClassif

### DIFF
--- a/R/PipeOpSmote.R
+++ b/R/PipeOpSmote.R
@@ -79,8 +79,8 @@ PipeOpSmote = R6Class("PipeOpSmote",
         # so it is a 'special_vals'.
         dup_size = p_int(lower = 1, default = 0, special_vals = list(0), tags = c("train", "smote"))
       )
-      super$initialize(id, param_set = ps, param_vals = param_vals,
-        packages = "smotefamily", can_subset_cols = FALSE, tags = "imbalanced data")
+      super$initialize(id, param_set = ps, param_vals = param_vals, can_subset_cols = FALSE,
+        packages = "smotefamily", task_type = "TaskClassif", tags = "imbalanced data")
     }
   ),
   private = list(
@@ -99,11 +99,10 @@ PipeOpSmote = R6Class("PipeOpSmote",
         .args = self$param_set$get_values(tags = "smote"),
         .opts = list(warnPartialMatchArgs = FALSE))$syn_data)
 
-      # rename target column and fix character conversion for TaskClassif
-      if (task$task_type == "classif") {
-        st[["class"]] = as_factor(st[["class"]], levels = task$class_names)
-      }
+      # rename target column and fix character conversion
+      st[["class"]] = as_factor(st[["class"]], levels = task$class_names)
       setnames(st, "class", task$target_names)
+      
       task$rbind(st)
     }
   )

--- a/tests/testthat/test_pipeop_smote.R
+++ b/tests/testthat/test_pipeop_smote.R
@@ -18,7 +18,7 @@ test_that("PipeOpSmote - basic properties", {
   expect_task(result[[1]])
 })
 
-test_that("compare to smotefamily::SMOT", {
+test_that("compare to smotefamily::SMOTE", {
   skip_if_not_installed("smotefamily")
   set.seed(1234)
   data = smotefamily::sample_generator(1000, ratio = 0.80)


### PR DESCRIPTION
`smotefamiliy::SMOTE()` does not work for non-classification tasks.