### PR TITLE
Add error message in PipeOpSmote for Tasks with non-feature cols

### DIFF
--- a/R/PipeOpSmote.R
+++ b/R/PipeOpSmote.R
@@ -87,7 +87,7 @@ PipeOpSmote = R6Class("PipeOpSmote",
 
     .train_task = function(task) {
       assert_true(all(task$feature_types$type == "numeric"))
-      cols = private$.select_cols(task)
+      cols = task$feature_names
 
       unsupported_cols = setdiff(unlist(task$col_roles), union(cols, task$target_names))
       if (length(unsupported_cols)) {

--- a/R/PipeOpSmote.R
+++ b/R/PipeOpSmote.R
@@ -89,6 +89,11 @@ PipeOpSmote = R6Class("PipeOpSmote",
       assert_true(all(task$feature_types$type == "numeric"))
       cols = private$.select_cols(task)
 
+      unsupported_cols = setdiff(unlist(task$col_roles), union(cols, task$target_names))
+      if (length(unsupported_cols)) {
+        stopf("The following columns are neither features nor targets, so SMOTE cannot generate synthetic data for them: '%s'. Please ensure that only feature or target columns are included.", paste(unsupported_cols, collapse = "', '"))
+      }
+
       if (!length(cols)) {
         return(task)
       }
@@ -102,7 +107,7 @@ PipeOpSmote = R6Class("PipeOpSmote",
       # rename target column and fix character conversion
       st[["class"]] = as_factor(st[["class"]], levels = task$class_names)
       setnames(st, "class", task$target_names)
-      
+
       task$rbind(st)
     }
   )

--- a/R/PipeOpSmote.R
+++ b/R/PipeOpSmote.R
@@ -91,7 +91,8 @@ PipeOpSmote = R6Class("PipeOpSmote",
 
       unsupported_cols = setdiff(unlist(task$col_roles), union(cols, task$target_names))
       if (length(unsupported_cols)) {
-        stopf("The following columns are neither features nor targets, so SMOTE cannot generate synthetic data for them: '%s'. Please ensure that only feature or target columns are included.", paste(unsupported_cols, collapse = "', '"))
+        stopf("SMOTE cannot generate synthetic data for the following columns since they are neither features nor targets: '%s'",
+              paste(unsupported_cols, collapse = "', '"))
       }
 
       if (!length(cols)) {


### PR DESCRIPTION
This adds an informative error message to `PipeOpSmote` for the case in which a task with columns is passed to the pipeop that SMOTE does not know how to handle, i.e. non-feature or non-target columns..

Addtionally, we replace `.select_cols(task)` with `task$feature_types` as this should only be used when overloading `.train_dt()` and `.predict_dt()` (see documentation of `PipeOpTaskPreproc`).

closes https://github.com/mlr-org/mlr3pipelines/issues/811