### PR TITLE
AB shortcuts for GraphLearner

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # mlr3pipelines 0.7.0-9000
 
 * New down-sampling PipeOps for inbalanced data: `PipeOpTomek` / `po("tomek")` and `PipeOpNearmiss` / `po("nearmiss")`
+* `GraphLearner` has new active bindings/methods as shortcuts for active bindings/methods of the underlying `Graph`:
+`$pipeops`, `$edges`, `$pipeops_param_set`, and `$pipeops_param_set_values` as well as `$ids()` and `$plot()`.
 
 # mlr3pipelines 0.7.0
 

--- a/R/Graph.R
+++ b/R/Graph.R
@@ -91,11 +91,12 @@
 #'   Takes a list of `Graph`s or [`PipeOp`]s (or objects that can be automatically converted into `Graph`s or [`PipeOp`]s,
 #'   see [`as_graph()`] and [`as_pipeop()`]) as inputs and joins them in a serial `Graph` coming after `self`, as if
 #'   connecting them using [`%>>%`].
-#' * `plot(html)` \cr
-#'   (`logical(1)`) -> `NULL` \cr
+#' * `plot(html = FALSE, horizontal = FALSE)` \cr
+#'   (`logical(1)`, `logical(1)`) -> `NULL` \cr
 #'   Plot the [`Graph`], using either the \pkg{igraph} package (for `html = FALSE`, default) or
 #'   the `visNetwork` package for `html = TRUE` producing a [`htmlWidget`][htmlwidgets::htmlwidgets].
 #'   The [`htmlWidget`][htmlwidgets::htmlwidgets] can be rescaled using [`visOptions`][visNetwork::visOptions].
+#'   For `html = FALSE`, the orientation of the plotted graph can be controlled through `horizontal`.
 #' * `print(dot = FALSE, dotname = "dot", fontsize = 24L)` \cr
 #'   (`logical(1)`, `character(1)`, `integer(1)`) -> `NULL` \cr
 #'   Print a representation of the [`Graph`] on the console. If `dot` is `FALSE`, output is a table with one row for each contained [`PipeOp`] and

--- a/R/GraphLearner.R
+++ b/R/GraphLearner.R
@@ -384,14 +384,15 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
       }
     },
     pipeops = function(rhs) {
-      if (!missing(rhs) && (!identical(rhs, private$.graph$pipeops || !identical(rhs, self$graph_model$pipeops)))) {
-        stop("pipeops is read-only")
-      }
-      if (is.null(self$model)) {
+      value = if (is.null(self$model)) {
         private$.graph$pipeops
       } else {
         self$graph_model$pipeops
       }
+      if (!missing(rhs) && (!identical(rhs, value))) {
+        stop("pipeops is read-only")
+      }
+      value
     },
     edges = function(rhs) {
       if (!missing(rhs) && !identical(rhs, private$.graph$edges)) {

--- a/R/GraphLearner.R
+++ b/R/GraphLearner.R
@@ -47,6 +47,16 @@
 #'   contain the model. Use `graph_model` to access the trained [`Graph`] after `$train()`. Read-only.
 #' * `graph_model` :: [`Learner`][mlr3::Learner]\cr
 #'   [`Graph`] that is being wrapped. This [`Graph`] contains a trained state after `$train()`. Read-only.
+#' * `pipeops` :: named `list` of [`PipeOp`] \cr
+#'   Contains all [`PipeOp`]s in the underlying [`Graph`], named by the [`PipeOp`]'s `$id`s. Read-only.
+#' * `edges` :: [`data.table`][data.table::data.table]  with columns `src_id` (`character`), `src_channel` (`character`), `dst_id` (`character`), `dst_channel` (`character`)\cr
+#'   Table of connections between the [`PipeOp`]s in the underlying [`Graph`]. A [`data.table`][data.table::data.table]. `src_id` and `dst_id` are `$id`s of [`PipeOp`]s that must be present in
+#'   the `$pipeops` list. `src_channel` and `dst_channel` must respectively be `$output` and `$input` channel names of the
+#'   respective [`PipeOp`]s.
+#' * `param_set` :: [`ParamSet`][paradox::ParamSet]\cr
+#'
+#' * pipeops_param_set
+#' * pipeops_param_set_values
 #' * `internal_tuned_values` :: named `list()` or `NULL`\cr
 #'   The internal tuned parameter values collected from all `PipeOp`s.
 #'   `NULL` is returned if the learner is not trained or none of the wrapped learners supports internal tuning.
@@ -75,6 +85,16 @@
 #'
 #' @section Methods:
 #' Methods inherited from [`Learner`][mlr3::Learner], as well as:
+#' * `ids(sorted = FALSE)` \cr
+#'   (`logical(1)`) -> `character` \cr
+#'   Get IDs of all [`PipeOp`]s. This is in order that [`PipeOp`]s were added if
+#'   `sorted` is `FALSE`, and topologically sorted if `sorted` is `TRUE`.
+#' * `plot(html = FALSE, horizontal = FALSE)` \cr
+#'   (`logical(1)`, `logical(1)`) -> `NULL` \cr
+#'   Plot the [`Graph`], using either the \pkg{igraph} package (for `html = FALSE`, default) or
+#'   the `visNetwork` package for `html = TRUE` producing a [`htmlWidget`][htmlwidgets::htmlwidgets].
+#'   The [`htmlWidget`][htmlwidgets::htmlwidgets] can be rescaled using [`visOptions`][visNetwork::visOptions].
+#'   For `html = FALSE`, the orientation of the plotted graph can be controlled through `horizontal`.
 #' * `marshal`\cr
 #'   (any) -> `self`\cr
 #'   Marshal the model.
@@ -104,11 +124,11 @@
 #' This works well for simple [`Graph`]s that do not modify features too much, but may give unexpected results for `Graph`s that
 #' add new features or move information between features.
 #'
-#' As an example, consider a feature `A`` with missing values, and a feature `B`` that is used for imputatoin, using a [`po("imputelearner")`][PipeOpImputeLearner].
-#' In a case where the following [`Learner`][mlr3::Learner] performs embedded feature selection and only selects feature A,
-#' the `selected_features()` method could return only feature `A``, and `$importance()` may even report 0 for feature `B`.
-#' This would not be entirbababababely accurate when considering the entire `GraphLearner`, as feature `B` is used for imputation and would therefore have an impact on predictions.
-#' The following should therefore only be used if the `Graph` is known to not have an impact on the relevant properties.
+#' As an example, consider a feature `A` with missing values, and a feature `B` that is used for imputation, using a [`po("imputelearner")`][PipeOpImputeLearner].
+#' In a case where the following [`Learner`][mlr3::Learner] performs embedded feature selection and only selects feature `A`,
+#' the `selected_features()` method could return only feature `A`, and `$importance()` may even report 0 for feature `B`.
+#' This would not be entirely accurate when considering the entire `GraphLearner`, as feature `B` is used for imputation and would therefore have an impact on predictions.
+#' The following should therefore only be used if the [`Graph`] is known to not have an impact on the relevant properties.
 #'
 #' * `importance()`\cr
 #'   () -> `numeric`\cr
@@ -288,6 +308,12 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
       } else {
         stopf("Baselearner %s of %s does not implement '$loglik()'.", base_learner$id, self$id)
       }
+    },
+    ids = function(sorted = FALSE) {
+      private$.graph$ids(sorted = sorted)
+    },
+    plot = function(html = FALSE, horizontal = FALSE, ...) {
+      private$.graph$plot(html = html, horizontal = horizontal, ...)
     }
   ),
   active = list(
@@ -341,12 +367,6 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
       }
       pt
     },
-    param_set = function(rhs) {
-      if (!missing(rhs) && !identical(rhs, self$graph$param_set)) {
-        stop("param_set is read-only.")
-      }
-      self$graph$param_set
-    },
     graph = function(rhs) {
       if (!missing(rhs) && !identical(rhs, private$.graph)) stop("graph is read-only")
       private$.graph
@@ -362,6 +382,42 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
         g$state = self$model
         g
       }
+    },
+    pipeops = function(rhs) {
+      if (!missing(rhs) && (!identical(rhs, private$.graph$pipeops || !identical(rhs, self$graph_model$pipeops)))) {
+        stop("pipeops is read-only")
+      }
+      if (is.null(self$model)) {
+        private$.graph$pipeops
+      } else {
+        self$graph_model$pipeops
+      }
+    },
+    edges = function(rhs) {
+      if (!missing(rhs) && !identical(rhs, private$.graph$edges)) {
+        stop("edges is read-only")
+      }
+      private$.graph$edges
+    },
+    param_set = function(rhs) {
+      if (!missing(rhs) && !identical(rhs, self$graph$param_set)) {
+        stop("param_set is read-only.")
+      }
+      self$graph$param_set
+    },
+    pipeops_param_set = function(rhs) {
+      value = map(self$graph$pipeops, "param_set")
+      if (!missing(rhs) && !identical(value, rhs)) {
+        stop("pipeops_param_set is read-only")
+      }
+      value
+    },
+    pipeops_param_set_values = function(rhs) {
+      value = map(glrn$pipeops, function(x) x$param_set$values)
+      if (!missing(rhs) && !identical(value, rhs)) {
+        stop("pipeops_param_set_values is read-only")
+      }
+      value
     }
   ),
   private = list(

--- a/R/GraphLearner.R
+++ b/R/GraphLearner.R
@@ -48,17 +48,15 @@
 #' * `graph_model` :: [`Learner`][mlr3::Learner]\cr
 #'   [`Graph`] that is being wrapped. This [`Graph`] contains a trained state after `$train()`. Read-only.
 #' * `pipeops` :: named `list` of [`PipeOp`] \cr
-#'   Contains all [`PipeOp`]s in the underlying [`Graph`], named by the [`PipeOp`]'s `$id`s.
+#'   Contains all [`PipeOp`]s in the underlying [`Graph`], named by the [`PipeOp`]'s `$id`s. Shortcut for `$graph_model$pipeops`. See [`Graph`] for details.
 #' * `edges` :: [`data.table`][data.table::data.table]  with columns `src_id` (`character`), `src_channel` (`character`), `dst_id` (`character`), `dst_channel` (`character`)\cr
-#'   Table of connections between the [`PipeOp`]s in the underlying [`Graph`]. A [`data.table`][data.table::data.table]. `src_id` and `dst_id` are `$id`s of [`PipeOp`]s that must be present in
-#'   the `$pipeops` list. `src_channel` and `dst_channel` must respectively be `$output` and `$input` channel names of the
-#'   respective [`PipeOp`]s.
+#'   Table of connections between the [`PipeOp`]s in the underlying [`Graph`]. Shortcut for `$graph$edges`. See [`Graph`] for details.
 #' * `param_set` :: [`ParamSet`][paradox::ParamSet]\cr
-#'   Shortcut for `$graph$param_set`.
+#'   Parameters of the underlying [`Graph`]. Shortcut for `$graph$param_set`. See [`Graph`] for details.
 #' * `pipeops_param_set` :: named `list()`\cr
-#'   Named list containing the [`ParamSet`][paradox::ParamSet]s of all [`PipeOp`]s in the [`Graph`].
+#'   Named list containing the [`ParamSet`][paradox::ParamSet]s of all [`PipeOp`]s in the [`Graph`]. See there for details.
 #' * `pipeops_param_set_values` :: named `list()`\cr
-#'   Named list containing the set parameter values of all [`PipeOp`]s in the [`Graph`].
+#'   Named list containing the set parameter values of all [`PipeOp`]s in the [`Graph`]. See there for details.
 #' * `internal_tuned_values` :: named `list()` or `NULL`\cr
 #'   The internal tuned parameter values collected from all [`PipeOp`]s.
 #'   `NULL` is returned if the learner is not trained or none of the wrapped learners supports internal tuning.
@@ -411,11 +409,14 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
       value
     },
     pipeops_param_set_values = function(rhs) {
-      value = map(self$graph$pipeops, function(x) x$param_set$values)
-      if (!missing(rhs) && !identical(value, rhs)) {
-        stop("pipeops_param_set_values is read-only")
+      if (!missing(rhs)) {
+        assert_list(rhs)
+        assert_names(names(rhs), permutation.of = names(self$graph$pipeops))
+        for (n in names(rhs)) {
+          self$graph$pipeops[[n]]$param_set$values = rhs[[n]]
+        }
       }
-      value
+      map(self$graph$pipeops, function(x) x$param_set$values)
     }
   ),
   private = list(

--- a/R/GraphLearner.R
+++ b/R/GraphLearner.R
@@ -48,24 +48,26 @@
 #' * `graph_model` :: [`Learner`][mlr3::Learner]\cr
 #'   [`Graph`] that is being wrapped. This [`Graph`] contains a trained state after `$train()`. Read-only.
 #' * `pipeops` :: named `list` of [`PipeOp`] \cr
-#'   Contains all [`PipeOp`]s in the underlying [`Graph`], named by the [`PipeOp`]'s `$id`s. Read-only.
+#'   Contains all [`PipeOp`]s in the underlying [`Graph`], named by the [`PipeOp`]'s `$id`s.
 #' * `edges` :: [`data.table`][data.table::data.table]  with columns `src_id` (`character`), `src_channel` (`character`), `dst_id` (`character`), `dst_channel` (`character`)\cr
 #'   Table of connections between the [`PipeOp`]s in the underlying [`Graph`]. A [`data.table`][data.table::data.table]. `src_id` and `dst_id` are `$id`s of [`PipeOp`]s that must be present in
 #'   the `$pipeops` list. `src_channel` and `dst_channel` must respectively be `$output` and `$input` channel names of the
 #'   respective [`PipeOp`]s.
 #' * `param_set` :: [`ParamSet`][paradox::ParamSet]\cr
-#'
-#' * pipeops_param_set
-#' * pipeops_param_set_values
+#'   Shortcut for `$graph$param_set`.
+#' * `pipeops_param_set` :: named `list()`\cr
+#'   Named list containing the [`ParamSet`][paradox::ParamSet]s of all [`PipeOp`]s in the [`Graph`].
+#' * `pipeops_param_set_values` :: named `list()`\cr
+#'   Named list containing the set parameter values of all [`PipeOp`]s in the [`Graph`].
 #' * `internal_tuned_values` :: named `list()` or `NULL`\cr
-#'   The internal tuned parameter values collected from all `PipeOp`s.
+#'   The internal tuned parameter values collected from all [`PipeOp`]s.
 #'   `NULL` is returned if the learner is not trained or none of the wrapped learners supports internal tuning.
 #' * `internal_valid_scores` :: named `list()` or `NULL`\cr
-#'   The internal validation scores as retrieved from the `PipeOps`.
-#'   The names are prefixed with the respective IDs of the `PipeOp`s.
+#'   The internal validation scores as retrieved from the [`PipeOp`]s.
+#'   The names are prefixed with the respective IDs of the [`PipeOp`]s.
 #'   `NULL` is returned if the learner is not trained or none of the wrapped learners supports internal validation.
 #' * `validate` :: `numeric(1)`, `"predefined"`, `"test"` or `NULL`\cr
-#'   How to construct the validation data. This also has to be configured for the individual `PipeOp`s such as
+#'   How to construct the validation data. This also has to be configured for the individual [`PipeOp`]s such as
 #'   `PipeOpLearner`, see [`set_validate.GraphLearner`].
 #'   For more details on the possible values, see [`mlr3::Learner`].
 #' * `marshaled` :: `logical(1)`\cr
@@ -384,11 +386,7 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
       }
     },
     pipeops = function(rhs) {
-      value = if (is.null(self$model)) {
-        private$.graph$pipeops
-      } else {
-        self$graph_model$pipeops
-      }
+      value = if (is.null(self$model)) private$.graph$pipeops else self$graph_model$pipeops
       if (!missing(rhs) && (!identical(rhs, value))) {
         stop("pipeops is read-only")
       }
@@ -413,6 +411,7 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
       }
       value
     },
+    # FIXME: assignment doesn't work
     pipeops_param_set_values = function(rhs) {
       value = map(glrn$pipeops, function(x) x$param_set$values)
       if (!missing(rhs) && !identical(value, rhs)) {

--- a/R/GraphLearner.R
+++ b/R/GraphLearner.R
@@ -386,11 +386,10 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
       }
     },
     pipeops = function(rhs) {
-      value = if (is.null(self$model)) private$.graph$pipeops else self$graph_model$pipeops
-      if (!missing(rhs) && (!identical(rhs, value))) {
+      if (!missing(rhs) && (!identical(rhs, self$graph_model$pipeops))) {
         stop("pipeops is read-only")
       }
-      value
+      self$graph_model$pipeops
     },
     edges = function(rhs) {
       if (!missing(rhs) && !identical(rhs, private$.graph$edges)) {
@@ -411,9 +410,8 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
       }
       value
     },
-    # FIXME: assignment doesn't work
     pipeops_param_set_values = function(rhs) {
-      value = map(glrn$pipeops, function(x) x$param_set$values)
+      value = map(self$graph$pipeops, function(x) x$param_set$values)
       if (!missing(rhs) && !identical(value, rhs)) {
         stop("pipeops_param_set_values is read-only")
       }

--- a/man/Graph.Rd
+++ b/man/Graph.Rd
@@ -104,11 +104,12 @@ are therefore unambiguous, they can be omitted (i.e. left as \code{NULL}).
 Takes a list of \code{Graph}s or \code{\link{PipeOp}}s (or objects that can be automatically converted into \code{Graph}s or \code{\link{PipeOp}}s,
 see \code{\link[=as_graph]{as_graph()}} and \code{\link[=as_pipeop]{as_pipeop()}}) as inputs and joins them in a serial \code{Graph} coming after \code{self}, as if
 connecting them using \code{\link{\%>>\%}}.
-\item \code{plot(html)} \cr
-(\code{logical(1)}) -> \code{NULL} \cr
+\item \code{plot(html = FALSE, horizontal = FALSE)} \cr
+(\code{logical(1)}, \code{logical(1)}) -> \code{NULL} \cr
 Plot the \code{\link{Graph}}, using either the \pkg{igraph} package (for \code{html = FALSE}, default) or
 the \code{visNetwork} package for \code{html = TRUE} producing a \code{\link[htmlwidgets:htmlwidgets-package]{htmlWidget}}.
 The \code{\link[htmlwidgets:htmlwidgets-package]{htmlWidget}} can be rescaled using \code{\link[visNetwork:visOptions]{visOptions}}.
+For \code{html = FALSE}, the orientation of the plotted graph can be controlled through \code{horizontal}.
 \item \code{print(dot = FALSE, dotname = "dot", fontsize = 24L)} \cr
 (\code{logical(1)}, \code{character(1)}, \code{integer(1)}) -> \code{NULL} \cr
 Print a representation of the \code{\link{Graph}} on the console. If \code{dot} is \code{FALSE}, output is a table with one row for each contained \code{\link{PipeOp}} and

--- a/man/mlr_learners_graph.Rd
+++ b/man/mlr_learners_graph.Rd
@@ -56,15 +56,25 @@ Fields inherited from \code{\link[mlr3:Learner]{Learner}}, as well as:
 contain the model. Use \code{graph_model} to access the trained \code{\link{Graph}} after \verb{$train()}. Read-only.
 \item \code{graph_model} :: \code{\link[mlr3:Learner]{Learner}}\cr
 \code{\link{Graph}} that is being wrapped. This \code{\link{Graph}} contains a trained state after \verb{$train()}. Read-only.
+\item \code{pipeops} :: named \code{list} of \code{\link{PipeOp}} \cr
+Contains all \code{\link{PipeOp}}s in the underlying \code{\link{Graph}}, named by the \code{\link{PipeOp}}'s \verb{$id}s. Shortcut for \verb{$graph_model$pipeops}. See \code{\link{Graph}} for details.
+\item \code{edges} :: \code{\link[data.table:data.table]{data.table}}  with columns \code{src_id} (\code{character}), \code{src_channel} (\code{character}), \code{dst_id} (\code{character}), \code{dst_channel} (\code{character})\cr
+Table of connections between the \code{\link{PipeOp}}s in the underlying \code{\link{Graph}}. Shortcut for \verb{$graph$edges}. See \code{\link{Graph}} for details.
+\item \code{param_set} :: \code{\link[paradox:ParamSet]{ParamSet}}\cr
+Parameters of the underlying \code{\link{Graph}}. Shortcut for \verb{$graph$param_set}. See \code{\link{Graph}} for details.
+\item \code{pipeops_param_set} :: named \code{list()}\cr
+Named list containing the \code{\link[paradox:ParamSet]{ParamSet}}s of all \code{\link{PipeOp}}s in the \code{\link{Graph}}. See there for details.
+\item \code{pipeops_param_set_values} :: named \code{list()}\cr
+Named list containing the set parameter values of all \code{\link{PipeOp}}s in the \code{\link{Graph}}. See there for details.
 \item \code{internal_tuned_values} :: named \code{list()} or \code{NULL}\cr
-The internal tuned parameter values collected from all \code{PipeOp}s.
+The internal tuned parameter values collected from all \code{\link{PipeOp}}s.
 \code{NULL} is returned if the learner is not trained or none of the wrapped learners supports internal tuning.
 \item \code{internal_valid_scores} :: named \code{list()} or \code{NULL}\cr
-The internal validation scores as retrieved from the \code{PipeOps}.
-The names are prefixed with the respective IDs of the \code{PipeOp}s.
+The internal validation scores as retrieved from the \code{\link{PipeOp}}s.
+The names are prefixed with the respective IDs of the \code{\link{PipeOp}}s.
 \code{NULL} is returned if the learner is not trained or none of the wrapped learners supports internal validation.
 \item \code{validate} :: \code{numeric(1)}, \code{"predefined"}, \code{"test"} or \code{NULL}\cr
-How to construct the validation data. This also has to be configured for the individual \code{PipeOp}s such as
+How to construct the validation data. This also has to be configured for the individual \code{\link{PipeOp}}s such as
 \code{PipeOpLearner}, see \code{\link{set_validate.GraphLearner}}.
 For more details on the possible values, see \code{\link[mlr3:Learner]{mlr3::Learner}}.
 \item \code{marshaled} :: \code{logical(1)}\cr
@@ -88,6 +98,16 @@ The default is \code{FALSE}.
 
 Methods inherited from \code{\link[mlr3:Learner]{Learner}}, as well as:
 \itemize{
+\item \code{ids(sorted = FALSE)} \cr
+(\code{logical(1)}) -> \code{character} \cr
+Get IDs of all \code{\link{PipeOp}}s. This is in order that \code{\link{PipeOp}}s were added if
+\code{sorted} is \code{FALSE}, and topologically sorted if \code{sorted} is \code{TRUE}.
+\item \code{plot(html = FALSE, horizontal = FALSE)} \cr
+(\code{logical(1)}, \code{logical(1)}) -> \code{NULL} \cr
+Plot the \code{\link{Graph}}, using either the \pkg{igraph} package (for \code{html = FALSE}, default) or
+the \code{visNetwork} package for \code{html = TRUE} producing a \code{\link[htmlwidgets:htmlwidgets-package]{htmlWidget}}.
+The \code{\link[htmlwidgets:htmlwidgets-package]{htmlWidget}} can be rescaled using \code{\link[visNetwork:visOptions]{visOptions}}.
+For \code{html = FALSE}, the orientation of the plotted graph can be controlled through \code{horizontal}.
 \item \code{marshal}\cr
 (any) -> \code{self}\cr
 Marshal the model.
@@ -118,9 +138,11 @@ Note that these typically only extract information from the \verb{$base_learner(
 This works well for simple \code{\link{Graph}}s that do not modify features too much, but may give unexpected results for \code{Graph}s that
 add new features or move information between features.
 
-As an example, consider a feature \verb{A`` with missing values, and a feature }B\verb{ that is used for imputatoin, using a [`po("imputelearner")`][PipeOpImputeLearner]. In a case where the following [`Learner`][mlr3::Learner] performs embedded feature selection and only selects feature A, the `selected_features()` method could return only feature `A}, and \verb{$importance()} may even report 0 for feature \code{B}.
-This would not be entirbababababely accurate when considering the entire \code{GraphLearner}, as feature \code{B} is used for imputation and would therefore have an impact on predictions.
-The following should therefore only be used if the \code{Graph} is known to not have an impact on the relevant properties.
+As an example, consider a feature \code{A} with missing values, and a feature \code{B} that is used for imputation, using a \code{\link[=PipeOpImputeLearner]{po("imputelearner")}}.
+In a case where the following \code{\link[mlr3:Learner]{Learner}} performs embedded feature selection and only selects feature \code{A},
+the \code{selected_features()} method could return only feature \code{A}, and \verb{$importance()} may even report 0 for feature \code{B}.
+This would not be entirely accurate when considering the entire \code{GraphLearner}, as feature \code{B} is used for imputation and would therefore have an impact on predictions.
+The following should therefore only be used if the \code{\link{Graph}} is known to not have an impact on the relevant properties.
 \itemize{
 \item \code{importance()}\cr
 () -> \code{numeric}\cr

--- a/tests/testthat/test_GraphLearner.R
+++ b/tests/testthat/test_GraphLearner.R
@@ -127,6 +127,7 @@ test_that("graphlearner parameters behave as they should", {
   dblrn = mlr_learners$get("classif.debug")
   dblrn$param_set$values$save_tasks = TRUE
 
+  # Graph ParamSet
   dbgr = PipeOpScale$new() %>>% PipeOpLearner$new(dblrn)
 
   expect_subset(c("scale.center", "scale.scale", "classif.debug.x"), dbgr$param_set$ids())
@@ -163,6 +164,7 @@ test_that("graphlearner parameters behave as they should", {
   expect_equal(dbgr$pipeops$classif.debug$param_set$values$x, 0.5)
   expect_equal(dbgr$pipeops$classif.debug$learner$param_set$values$x, 0.5)
 
+  # Graph Learner ParamSet
   dblrn = mlr_learners$get("classif.debug")
   dblrn$param_set$values$message_train = 1
   dblrn$param_set$values$message_predict = 1
@@ -177,6 +179,32 @@ test_that("graphlearner parameters behave as they should", {
 
   expect_mapequal(gl$param_set$values,
     list(classif.debug.message_predict = 0, classif.debug.message_train = 1, classif.debug.warning_predict = 0, classif.debug.warning_train = 1))
+
+  # GraphLearner AB shortcuts
+  gl = GraphLearner$new(dbgr)
+
+  # GraphLearner AB $pipeops
+  expect_no_error({gl$pipeops$classif.debug$param_set$values$x = 0.5})
+  expect_equal(gl$pipeops$classif.debug$param_set$values$x, 0.5)
+  expect_equal(gl$graph_model$pipeops$classif.debug$param_set$values$x, 0.5)
+
+  # GraphLearner AB $pipeops_param_set
+  expect_no_error({gl$pipeops_param_set$classif.debug$values$x = 0})
+  expect_equal(gl$pipeops_param_set$classif.debug$values$x, 0)
+  expect_equal(gl$graph_model$pipeops$classif.debug$param_set$values$x, 0)
+
+  # GraphLearner AB $pipeops_param_set_values
+  expect_no_error({gl$pipeops_param_set_values$classif.debug$x = 1})
+  expect_equal(gl$pipeops_param_set_values$classif.debug$x, 1)
+  expect_equal(gl$graph_model$pipeops$classif.debug$param_set$values$x, 1)
+
+  # Change param_set pointer should throw error
+  expect_error({gl$pipeops$scale$param_set = ps()})
+  expect_error({gl$pipeops_param_set$scale = ps()})
+  # Lists with wrong properties should not be accepted
+  expect_error({gl$pipeops_param_set_values = list()})
+  expect_error({gl$pipeops_param_set_values = list(x = 5)})
+
 })
 
 test_that("graphlearner type inference", {


### PR DESCRIPTION
New active bindings in `GraphLearner`:
- `$pipeops` and `$edges` as shortcuts for `$graph_model$pipeops` and `$graph$edges`
- `$pipeops_param_set` and `$pipeops_param_set_values` that each generate a named list with names according to the pipeops, giving their respective `param_set` or `param_set$values`.

As well as new methods:
- `ids()` and `plot()` as shortcuts for `$graph$ids()` and `$graph$plot()`

closes https://github.com/mlr-org/mlr3pipelines/issues/600
closes https://github.com/mlr-org/mlr3pipelines/issues/800