### PR TITLE
Fix: Add `set.seed()` in BLSmote tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * New parameter `new_role_direct` for `PipeOpColRoles` / `po("colroles")` to change column roles by role instead of by column.
 * Dictionary sugar functions `po()` / `pos()` / `ppl()` / `ppls()` now make suggestions for entries in both `mlr_pipeops` as well as `mlr_graphs` when an object by the given name could not be found in the respective dictionary.
 * New PipeOp `PipeOpDecode` / `po("decode")` to reverse one-hot or treatment encoding.
+* Fix: Made tests for `PipeOpBLSmote` deterministic.
 
 # mlr3pipelines 0.7.1
 

--- a/tests/testthat/test_pipeop_blsmote.R
+++ b/tests/testthat/test_pipeop_blsmote.R
@@ -13,6 +13,7 @@ test_that("PipeOpBLSmote - train works as intended", {
 
   op = PipeOpBLSmote$new()
 
+  set.seed(1234)
   df = smotefamily::sample_generator(500, 0.8)
   df$result = factor(df$result)
   df = df[, c(3L, 1L, 2L)]  # we do this to avoid reordering later
@@ -75,6 +76,7 @@ test_that("PipeOpBLSmote - handling of feature named 'class'", {
 
   op = PipeOpBLSmote$new()
 
+  set.seed(1234)
   df = smotefamily::sample_generator(500, 0.8)
   df$result = factor(df$result)
   # Rename a column into "class"


### PR DESCRIPTION
Added `set.seed()` for `smotefamily::sample_generator()` in tests for `PipeOpBLSmote`.