### PR TITLE
feat: hotstart

### DIFF
--- a/R/Graph.R
+++ b/R/Graph.R
@@ -449,10 +449,12 @@ Graph = R6Class("Graph",
       self$set_names(ids, sprintf("%s%s%s", assert_string(prefix), ids, assert_string(postfix)))
       invisible(self)
     },
+
     train = function(input, single_input = TRUE) {
       graph_load_namespaces(self, "train")
       graph_reduce(self, input, "train", single_input)
     },
+
     predict = function(input, single_input = TRUE) {
       graph_load_namespaces(self, "predict")
       graph_reduce(self, input, "predict", single_input)

--- a/R/Graph.R
+++ b/R/Graph.R
@@ -449,15 +449,17 @@ Graph = R6Class("Graph",
       self$set_names(ids, sprintf("%s%s%s", assert_string(prefix), ids, assert_string(postfix)))
       invisible(self)
     },
-
     train = function(input, single_input = TRUE) {
       graph_load_namespaces(self, "train")
       graph_reduce(self, input, "train", single_input)
     },
-
     predict = function(input, single_input = TRUE) {
       graph_load_namespaces(self, "predict")
       graph_reduce(self, input, "predict", single_input)
+    },
+    hotstart = function(input, single_input = TRUE) {
+      graph_load_namespaces(self, "train")
+      graph_reduce(self, input, "hotstart", single_input)
     },
     help = function(help_type = getOption("help_type")) {
       parts = strsplit(self$man, split = "::", fixed = TRUE)[[1]]

--- a/R/GraphLearner.R
+++ b/R/GraphLearner.R
@@ -454,6 +454,7 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
       }
 
       on.exit({self$graph$state = NULL})
+
       self$graph$train(task)
       state = self$graph$state
       class(state) = c("graph_learner_model", class(state))
@@ -466,6 +467,23 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
       assert_list(prediction, types = "Prediction", len = 1,
         .var.name = sprintf("Prediction returned by Graph %s", self$id))
       prediction[[1]]
+    },
+
+    .hotstart = function(task) {
+      if (!is.null(get0("validate", self))) {
+        some_pipeops_validate = some(pos_with_property(self, "validation"), function(po) !is.null(po$validate))
+        if (!some_pipeops_validate) {
+          lg$warn("GraphLearner '%s' specifies a validation set, but none of its PipeOps use it.", self$id)
+        }
+      }
+
+      on.exit({self$graph$state = NULL})
+      # copy hotstart state to graph
+      self$graph$state = self$state$model
+      self$graph$hotstart(task)
+      state = self$graph$state
+      class(state) = c("graph_learner_model", class(state))
+      state
     }
   )
 )

--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -349,6 +349,8 @@ PipeOp = R6Class("PipeOp",
       output
     },
     hotstart = function(input) {
+      # default for all pipops is to just train them
+      # pipeops that can do hotstarting should overload this method
       self$train(input)
     },
     help = function(help_type = getOption("help_type")) {

--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -348,6 +348,9 @@ PipeOp = R6Class("PipeOp",
       output = check_types(self, output, "output", "predict")
       output
     },
+    hotstart = function(input) {
+      self$train(input)
+    },
     help = function(help_type = getOption("help_type")) {
       parts = strsplit(self$man, split = "::", fixed = TRUE)[[1]]
       match.fun("help")(parts[[2]], package = parts[[1]], help_type = help_type)

--- a/R/PipeOpLearner.R
+++ b/R/PipeOpLearner.R
@@ -211,7 +211,6 @@ PipeOpLearner = R6Class("PipeOpLearner", inherit = PipeOp,
       private$.learner$state = self$state
       list(private$.learner$predict(task))
     },
-
     .additional_phash_input = function() private$.learner$phash
   )
 )

--- a/R/PipeOpLearner.R
+++ b/R/PipeOpLearner.R
@@ -119,6 +119,7 @@ PipeOpLearner = R6Class("PipeOpLearner", inherit = PipeOp,
       learner = private$.learner
       learner$state = self$state
 
+      # train learner with hotstarting
       train_result = mlr3:::learner_train(learner, task = input[[1]], train_row_ids = NULL, mode = "hotstart")
       self$state = train_result$learner$state
 

--- a/R/PipeOpLearner.R
+++ b/R/PipeOpLearner.R
@@ -114,9 +114,14 @@ PipeOpLearner = R6Class("PipeOpLearner", inherit = PipeOp,
       )
     },
     hotstart = function(input) {
+      on.exit({private$.learner$state = NULL})
       # copy state to learner
-      private$.learner$state = self$state
-      output = get_private(private$.learner)$.hotstart(input[[1]])
+      learner = private$.learner
+      learner$state = self$state
+
+      train_result = mlr3:::learner_train(learner, task = input[[1]], train_row_ids = NULL, mode = "hotstart")
+      self$state = train_result$learner$state
+
       list(NULL)
     }
   ),

--- a/R/PipeOpLearner.R
+++ b/R/PipeOpLearner.R
@@ -114,8 +114,8 @@ PipeOpLearner = R6Class("PipeOpLearner", inherit = PipeOp,
       )
     },
     hotstart = function(input) {
-      # copy model from state to learner
-      private$.learner$state$model = self$state$model
+      # copy state to learner
+      private$.learner$state = self$state
       output = get_private(private$.learner)$.hotstart(input[[1]])
       list(NULL)
     }

--- a/R/PipeOpLearner.R
+++ b/R/PipeOpLearner.R
@@ -112,6 +112,12 @@ PipeOpLearner = R6Class("PipeOpLearner", inherit = PipeOp,
         output = data.table(name = "output", train = "NULL", predict = out_type),
         tags = "learner", packages = learner$packages, properties = properties
       )
+    },
+    hotstart = function(input) {
+      # copy model from state to learner
+      private$.learner$state$model = self$state$model
+      output = get_private(private$.learner)$.hotstart(input[[1]])
+      list(NULL)
     }
   ),
   active = list(
@@ -199,6 +205,7 @@ PipeOpLearner = R6Class("PipeOpLearner", inherit = PipeOp,
       private$.learner$state = self$state
       list(private$.learner$predict(task))
     },
+
     .additional_phash_input = function() private$.learner$phash
   )
 )


### PR DESCRIPTION
Nothing to merge yet but a poc we should discuss. `mlr3tuning` is ready to use hotstarting efficiently and @sebffischer wants to use hotstarting for torch. This currently only works for pipelines that are deterministic until the hotstart model is reached. 

Further thoughts on this. Actually, the task would no longer have to be sent through the pipeline during hotstarting. If you cache the task before the hotstart model, you can simply continue there. However, this would somehow require the task to be cached at this point during the first training. 