### PR TITLE
Fix: Remove usage of `$clone()` on uncloneable `mlr_pipeops` dictionary from tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * Fix: Columns that are `feature` and something else no longer lose the other column role during training or predicting of `PipeOp`s inheriting from `PipeOpTaskPreproc`.
 * Fix: Made tests for `PipeOpBLSmote` deterministic.
 * Fix: Corrected hash calculation for `PipeOpFilter`.
+* Compatibility with new `R6` release.
 
 # mlr3pipelines 0.7.1
 

--- a/tests/testthat/test_dictionary.R
+++ b/tests/testthat/test_dictionary.R
@@ -246,8 +246,10 @@ test_that("mlr_graphs dictionary", {
 })
 
 test_that("Cannot add pipeops with keys that invalidates the convenience for id incrementation", {
-  copy = mlr_pipeops$clone(deep = TRUE)
-  expect_error(copy$add("name_1", PipeOp), regexp = "grepl")
+  expect_error(mlr_pipeops$add("name_1", PipeOp), regexp = "grepl")
+  if ("name_1" %in% mlr_pipeops$keys()) {
+    mlr_pipeops$remove("name_1")
+  }
 })
 
 test_that("as.data.table(mlr_pipeops) works when a pipeop can not be constructed", {


### PR DESCRIPTION
Closes https://github.com/mlr-org/mlr3pipelines/issues/875