### PR TITLE
Remove superfluous tests covered by expect_datapreproc_pipeop_class

### DIFF
--- a/tests/testthat/test_pipeop_boxcox.R
+++ b/tests/testthat/test_pipeop_boxcox.R
@@ -4,15 +4,7 @@ test_that("PipeOpBoxCox - general functionality", {
   skip_if_not_installed("bestNormalize")
   task = mlr_tasks$get("iris")
   op = PipeOpBoxCox$new()
-  expect_pipeop(op)
-
   expect_datapreproc_pipeop_class(PipeOpBoxCox, task = task)
-
-  result = train_pipeop(op, inputs = list(task))
-  expect_task(result[[1]])
-
-  result = predict_pipeop(op, inputs = list(task))
-  expect_task(result[[1]])
 })
 
 test_that("PipeOpBoxCox - receive expected result", {

--- a/tests/testthat/test_pipeop_colroles.R
+++ b/tests/testthat/test_pipeop_colroles.R
@@ -1,16 +1,9 @@
 context("PipeOpColRoles")
 
 test_that("PipeOpColRoles - basic properties", {
-
   op = PipeOpColRoles$new()
   task = mlr_tasks$get("iris")
-
-  expect_pipeop(op)
-  expect_equal(task, train_pipeop(op, inputs = list(task))$output)
-  expect_equal(task, predict_pipeop(op, inputs = list(task))$output)
-
   expect_datapreproc_pipeop_class(PipeOpColRoles, task = task)
-
 })
 
 test_that("PipeOpColRoles - assertions on params work", {

--- a/tests/testthat/test_pipeop_datefeatures.R
+++ b/tests/testthat/test_pipeop_datefeatures.R
@@ -7,9 +7,6 @@ test_that("PipeOpDateFeatures - basic properties", {
     size = 150L)
   task = TaskClassif$new("iris_date", backend = dat, target = "Species")
   po = PipeOpDateFeatures$new()
-  expect_pipeop(po)
-  train_pipeop(po, inputs = list(task))
-  predict_pipeop(po, inputs = list(task))
   expect_datapreproc_pipeop_class(PipeOpDateFeatures, task = task)
 })
 
@@ -190,7 +187,7 @@ test_that("PipeOpDateFeatures - only year and cyclic", {
   po$param_set$values$minute = FALSE
   po$param_set$values$second = FALSE
   po$param_set$values$is_day = FALSE
-  expect_true("date.year" %in% train_pipeop(po, inputs = list(task))$output$feature_names)  
+  expect_true("date.year" %in% train_pipeop(po, inputs = list(task))$output$feature_names)
 })
 
 test_that("PipeOpDateFeatures - two POSIXct variables", {

--- a/tests/testthat/test_pipeop_encodeimpact.R
+++ b/tests/testthat/test_pipeop_encodeimpact.R
@@ -15,7 +15,6 @@ test_that("PipeOpEncodeImpact", {
   expect_datapreproc_pipeop_class(PipeOpEncodeImpact, task = mlr_tasks$get("iris"))
 
   op = PipeOpEncodeImpact$new()
-  expect_pipeop(op)
 
   nt = train_pipeop(op, inputs = list(task))[[1L]]
   fn = nt$feature_names

--- a/tests/testthat/test_pipeop_encodelmer.R
+++ b/tests/testthat/test_pipeop_encodelmer.R
@@ -15,7 +15,6 @@ test_that("PipeOpEncodeLmer regr", {
   expect_datapreproc_pipeop_class(PipeOpEncodeLmer, task = task)
   expect_datapreproc_pipeop_class(PipeOpEncodeLmer, task = mlr_tasks$get("iris"))
   op = PipeOpEncodeLmer$new()
-  expect_pipeop(op)
   nt = train_pipeop(op, inputs = list(task))[[1L]]
   fn = nt$feature_names
   expect_true("factor" %nin% nt$feature_types$type)

--- a/tests/testthat/test_pipeop_fixfactors.R
+++ b/tests/testthat/test_pipeop_fixfactors.R
@@ -11,7 +11,6 @@ test_that("PipeOpFixFactors", {
   expect_datapreproc_pipeop_class(PipeOpFixFactors, task = mlr_tasks$get("iris"))
 
   op = PipeOpFixFactors$new()
-  expect_pipeop(op)
 
   nt = train_pipeop(op, inputs = list(task))[[1L]]
   fn = nt$feature_names

--- a/tests/testthat/test_pipeop_histbin.R
+++ b/tests/testthat/test_pipeop_histbin.R
@@ -3,13 +3,10 @@ context("PipeOpHistBin")
 test_that("PipeOpHistBin - basic properties", {
   task = mlr_tasks$get("iris")
   op = PipeOpHistBin$new()
-  expect_pipeop(op)
-  result = op$train(list(task))
 
   expect_datapreproc_pipeop_class(PipeOpHistBin, task = task)
-  expect_task(result[[1L]])
-  expect_equal(result[[1L]]$data(), op$predict(list(task))[[1L]]$data())
 
+  result = op$train(list(task))
   a = apply(result[[1L]]$data()[, 2:5], MARGIN = 2L,
     function(x) expect_true(!anyMissing(x)))
 })

--- a/tests/testthat/test_pipeop_ica.R
+++ b/tests/testthat/test_pipeop_ica.R
@@ -6,14 +6,6 @@ test_that("PipeOpICA - basic properties", {
 
   expect_datapreproc_pipeop_class(PipeOpICA, task = task,
     deterministic_train = FALSE)
-
-  op = PipeOpICA$new()
-  expect_pipeop(op)
-  set.seed(1234)
-  result = op$train(list(task))
-
-  expect_task(result[[1]])
-  expect_equal(result[[1]]$data(), op$predict(list(task))[[1]]$data())
 })
 
 test_that("PipeOpICA - compare to fastICA", {

--- a/tests/testthat/test_pipeop_nmf.R
+++ b/tests/testthat/test_pipeop_nmf.R
@@ -2,10 +2,7 @@ context("PipeOpNMF")
 
 test_that("basic properties", {
   skip_if_not_installed("NMF")
-  op = PipeOpNMF$new()
   task = mlr_tasks$get("iris")
-  expect_pipeop(op)
-
   expect_datapreproc_pipeop_class(PipeOpNMF, task = task, deterministic_train = FALSE)
 })
 

--- a/tests/testthat/test_pipeop_pca.R
+++ b/tests/testthat/test_pipeop_pca.R
@@ -6,13 +6,6 @@ test_that("PipeOpPCA - basic properties", {
   expect_pipeop(op)
 
   expect_datapreproc_pipeop_class(PipeOpPCA, task = task)
-
-  # FIXME: either we dont need this, as this is already ensured in PipeOp, or we should test this in expect_pipeop
-  result = train_pipeop(op, inputs = list(task))
-  expect_task(result[[1]])
-
-  result = predict_pipeop(op, inputs = list(task))
-  expect_task(result[[1]])
 })
 
 

--- a/tests/testthat/test_pipeop_quantilebin.R
+++ b/tests/testthat/test_pipeop_quantilebin.R
@@ -3,11 +3,6 @@ context("PipeOpQuantileBin")
 test_that("PipeOpQuantileBin - basic properties", {
   task = mlr_tasks$get("iris")
   expect_datapreproc_pipeop_class(PipeOpQuantileBin, task = task)
-  op = PipeOpQuantileBin$new()
-  expect_pipeop(op)
-  result = op$train(list(task))
-  expect_task(result[[1]])
-  expect_equal(result[[1]]$data(), op$predict(list(task))[[1]]$data())
 })
 
 test_that("PipeOpQuantileBin - see if expected result is returned", {

--- a/tests/testthat/test_pipeop_randomprojection.R
+++ b/tests/testthat/test_pipeop_randomprojection.R
@@ -3,16 +3,7 @@ context("RandomProjection")
 test_that("basic properties", {
   task = mlr_tasks$get("iris")
   op = PipeOpRandomProjection$new()
-
-  expect_pipeop(op)
   expect_datapreproc_pipeop_class(PipeOpRandomProjection, task = task, deterministic_train = FALSE)
-
-  set.seed(1234)
-  result = op$train(list(task))
-  resdt = result[[1]]$data()
-
-  expect_task(result[[1]])
-  expect_equal(resdt, op$predict(list(task))[[1]]$data())
 })
 
 test_that("projection properties", {

--- a/tests/testthat/test_pipeop_removeconstants.R
+++ b/tests/testthat/test_pipeop_removeconstants.R
@@ -3,12 +3,7 @@ context("PipeOpRemoveConstants")
 test_that("PipeOpRemoveConstants - basic properties", {
   task = mlr_tasks$get("boston_housing_classic")
   task$cbind(data.table(xx = rep(1, 506), yy = rep("a", 506)))
-
-  op = PipeOpRemoveConstants$new()
-  expect_pipeop(op)
-
   expect_datapreproc_pipeop_class(PipeOpRemoveConstants, task = task)
-
 })
 
 test_that("PipeOpRemoveConstants removes expected cols", {

--- a/tests/testthat/test_pipeop_renamecolumns.R
+++ b/tests/testthat/test_pipeop_renamecolumns.R
@@ -3,11 +3,6 @@ context("PipeOpRenameColumns")
 test_that("basic properties", {
   task = mlr_tasks$get("iris")
   op = PipeOpRenameColumns$new()
-  expect_pipeop(op)
-  train_out = op$train(list(task))[[1L]]
-  predict_out = op$predict(list(task))[[1L]]
-  expect_equal(train_out, task)
-  expect_equal(predict_out, task)
   expect_datapreproc_pipeop_class(PipeOpRenameColumns, task = task, predict_like_train = TRUE)
 })
 

--- a/tests/testthat/test_pipeop_rowapply.R
+++ b/tests/testthat/test_pipeop_rowapply.R
@@ -1,17 +1,12 @@
 context("PipeOpRowApply")
 
 test_that("PipeOpRowApply - basic properties", {
-
   op = PipeOpRowApply$new()
   task = mlr_tasks$get("iris")
-  expect_pipeop(op)
-
   expect_datapreproc_pipeop_class(PipeOpRowApply, task = task)
-
 })
 
 test_that("PipeOpRowApply - transform on task with only numeric features", {
-
   op = PipeOpRowApply$new()
   task = mlr_tasks$get("iris")
   cnames = task$feature_names

--- a/tests/testthat/test_pipeop_scale.R
+++ b/tests/testthat/test_pipeop_scale.R
@@ -3,15 +3,7 @@ context("PipeOpScale")
 test_that("PipeOpScale - basic properties", {
   op = PipeOpScale$new()
   task = mlr_tasks$get("iris")
-  expect_pipeop(op)
-
   expect_datapreproc_pipeop_class(PipeOpScale, task = task)
-
-  result = train_pipeop(op, inputs = list(task))
-  expect_task(result[[1]])
-
-  result = predict_pipeop(op, inputs = list(task))
-  expect_task(result[[1]])
 })
 
 test_that("basic properties", {

--- a/tests/testthat/test_pipeop_scalemaxabs.R
+++ b/tests/testthat/test_pipeop_scalemaxabs.R
@@ -3,15 +3,10 @@ context("PipeOpScaleMaxAbs")
 test_that("PipeOpScaleMaxAbs - basic properties", {
   task = mlr_tasks$get("iris")
   op = PipeOpScaleMaxAbs$new()
-  expect_pipeop(op)
   expect_datapreproc_pipeop_class(PipeOpScaleMaxAbs, task = task)
 
   set.seed(1234)
-  result = op$train(list(task))
-  resdt = result[[1]]$data()
-
-  expect_task(result[[1]])
-  expect_equal(resdt, op$predict(list(task))[[1]]$data())
+  resdt = op$train(list(task))[[1]]$data()
   expect_true(all(sapply(resdt[, 2:5], max) == 1L))
   resmin = sapply(task$data()[, 2:5], min)/sapply(task$data()[, 2:5], max)
   expect_identical(sapply(resdt[, 2:5], min), resmin)
@@ -22,8 +17,7 @@ test_that("Other maxabs", {
 
   op = PipeOpScaleMaxAbs$new(param_vals = list(maxabs = 0.6))
   set.seed(1234)
-  result = op$train(list(task))
-  resdt = result[[1]]$data()
+  resdt = op$train(list(task))[[1L]]$data()
   expect_true(all(sapply(resdt[, 2:5], max) == 0.6))
   resmin = (sapply(task$data()[, 2:5], min)/sapply(task$data()[, 2:5], max))*0.6
   expect_identical(sapply(resdt[, 2:5], min), resmin)

--- a/tests/testthat/test_pipeop_scalerange.R
+++ b/tests/testthat/test_pipeop_scalerange.R
@@ -4,14 +4,10 @@ test_that("PipeOpScaleRange - basic properties", {
   task = mlr_tasks$get("iris")
   op = PipeOpScaleRange$new()
 
-  expect_pipeop(op)
   expect_datapreproc_pipeop_class(PipeOpScaleRange, task = task)
 
   set.seed(1234)
-  result = op$train(list(task))
-  resdt = result[[1]]$data()
-
-  expect_task(result[[1]])
+  resdt = op$train(list(task))[[1]]$data()
   expect_equal(resdt, op$predict(list(task))[[1]]$data())
   expect_true(all(sapply(resdt[, 2:5], max) == 1L))
   expect_true(all(sapply(resdt[, 2:5], min) == 0L))
@@ -21,8 +17,7 @@ test_that("Other maxabs", {
   task = mlr_tasks$get("iris")
   op = PipeOpScaleRange$new(param_vals = list(upper = 0.6, lower = 0.2))
   set.seed(1234)
-  result = op$train(list(task))
-  resdt = result[[1]]$data()
+  resdt = op$train(list(task))[[1]]$data()
   resdt.max = sapply(resdt[, 2:5], max)
   names(resdt.max) = NULL
   expect_equal(resdt.max, rep(0.6, 4))

--- a/tests/testthat/test_pipeop_spatialsign.R
+++ b/tests/testthat/test_pipeop_spatialsign.R
@@ -3,12 +3,7 @@ context("PipeOpSpatialSign")
 test_that("PipeOpSpatialSign - general functionality", {
   task = mlr_tasks$get("iris")
   op = PipeOpSpatialSign$new()
-  expect_pipeop(op)
   expect_datapreproc_pipeop_class(PipeOpSpatialSign, task = task)
-  result = train_pipeop(op, inputs = list(task))
-  expect_task(result[[1]])
-  result = predict_pipeop(op, inputs = list(task))
-  expect_task(result[[1]])
 })
 
 test_that("PipeOpSpatialSign - receive expected result", {

--- a/tests/testthat/test_pipeop_subsample.R
+++ b/tests/testthat/test_pipeop_subsample.R
@@ -3,10 +3,6 @@ context("PipeOpSubsample")
 test_that("PipeOpSubsample - basic properties", {
   op = PipeOpSubsample$new()
   task = mlr_tasks$get("iris")
-  expect_pipeop(op)
-  train_pipeop(op, inputs = list(task))
-  predict_pipeop(op, inputs = list(task))
-
   expect_datapreproc_pipeop_class(PipeOpSubsample, task = task, predict_like_train = FALSE, deterministic_train = FALSE)
 })
 

--- a/tests/testthat/test_pipeop_vtreat.R
+++ b/tests/testthat/test_pipeop_vtreat.R
@@ -174,6 +174,7 @@ test_that("PipeOpVtreat - Edge Cases", {
     weights = rep(c(1L, 2L), 6L))
 
   task = TaskRegr$new("test", backend = dat, target = "y")
+  # Compatibility with upcoming new weights_learner role in mlr3
   task$col_roles[[if ("weights_learner" %in% names(task)) "weights_learner" else "weight"]] = "weights"
   task$col_roles$feature = "x"
 
@@ -184,6 +185,7 @@ test_that("PipeOpVtreat - Edge Cases", {
   expect_true(colnames(train_out1$data()) == "y")
   expect_equal(train_out1$data(), predict_out1$data())
 
+  # Compatibility with upcoming new weights_learner role in mlr3
   task$col_roles[[if ("weights_learner" %in% names(task)) "weights_learner" else "weight"]] = character()
   train_out2 = po$train(list(task))[[1L]]
   predict_out2 = po$predict(list(task))[[1L]]

--- a/tests/testthat/test_pipeop_yeojohnson.R
+++ b/tests/testthat/test_pipeop_yeojohnson.R
@@ -4,12 +4,7 @@ test_that("PipeOpYeoJohnson - general functionality", {
   skip_if_not_installed("bestNormalize")
   task = mlr_tasks$get("iris")
   op = PipeOpYeoJohnson$new()
-  expect_pipeop(op)
   expect_datapreproc_pipeop_class(PipeOpYeoJohnson, task = task)
-  result = train_pipeop(op, inputs = list(task))
-  expect_task(result[[1]])
-  result = predict_pipeop(op, inputs = list(task))
-  expect_task(result[[1]])
 })
 
 test_that("PipeOpYeoJohnson - receive expected result", {


### PR DESCRIPTION
closes https://github.com/mlr-org/mlr3pipelines/issues/892
Note, that `pipeop_train()` does one minimally different test, i.e. it tests that the PO's state is NULL / not NULL where appropriate. The autotests does this indirectly by testing `is_trained`. 