### PR TITLE
Changes in tests to be compatible mlr3 dev version 0.23.0.9000

### DIFF
--- a/tests/testthat/test_pipeop_colapply.R
+++ b/tests/testthat/test_pipeop_colapply.R
@@ -120,7 +120,7 @@ test_that("apply results look as they should", {
 
 test_that("empty task", {
 
-  task = tsk("iris")$filter(0L)
+  task = tsk("iris")$filter(integer(0))
   po = PipeOpColApply$new()
   po$param_set$values$applicator = function(x) as.integer(x)
 

--- a/tests/testthat/test_pipeop_rowapply.R
+++ b/tests/testthat/test_pipeop_rowapply.R
@@ -354,7 +354,7 @@ test_that("PipeOpRowApply - transform works on task with only one row", {
 test_that("PipeOpRowApply - transform works on empty task (no rows)", {
 
   op = PipeOpRowApply$new()
-  task = mlr_tasks$get("wine")$filter(0)
+  task = mlr_tasks$get("wine")$clone(deep = TRUE)$filter(integer(0))
   cnames = task$feature_names
 
   # applicator generates matrix with names
@@ -426,7 +426,7 @@ test_that("PipeOpRowApply - transform works for empty predict task (no rows)", {
 
   op = PipeOpRowApply$new()
   task_train = mlr_tasks$get("wine")
-  task_predict = task_train$filter(0)
+  task_predict = task_train$clone(deep = TRUE)$filter(integer(0))
   cnames = task_train$feature_names
 
   # applicator generates matrix with names


### PR DESCRIPTION
- changed creation of empty tasks to `task$filter(integer(0))` instead of `task$filter(0)`
- set `predict.type` consistently in tests for `PipeOpTunethreshold` to avoid new warning message