### PR TITLE
Remove `kknn` dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -95,7 +95,6 @@ Suggests:
     evaluate,
     NMF,
     MASS,
-    kknn,
     GenSA,
     methods,
     vtreat,

--- a/R/PipeOpImputeLearner.R
+++ b/R/PipeOpImputeLearner.R
@@ -83,11 +83,11 @@
 #' po$state$model$mass
 #'
 #' library("mlr3learners")
-#' # to use the "regr.kknn" Learner, prefix it with its own imputation method!
-#' # The "imputehist" PipeOp is used to train "regr.kknn"; predictions of this
+#' # To use the "regr.lm" Learner, prefix it with its own imputation method!
+#' # The "imputehist" PipeOp is used to train "regr.lm"; predictions of this
 #' # trained Learner are then used to impute the missing values in the Task.
 #' po = po("imputelearner",
-#'   po("imputehist") %>>% lrn("regr.kknn")
+#'   po("imputehist") %>>% lrn("regr.lm")
 #' )
 #'
 #' new_task = po$train(list(task = task))[[1]]

--- a/R/PipeOpProxy.R
+++ b/R/PipeOpProxy.R
@@ -57,17 +57,16 @@
 #'
 #' @examplesIf requireNamespace("rpart")
 #' library("mlr3")
-#' library("mlr3learners")
 #'
 #' set.seed(1234)
 #' task = tsk("iris")
 #'
 #' # use a proxy for preprocessing and a proxy for learning, i.e.,
-#' # no preprocessing and classif.kknn
+#' # no preprocessing and classif.rpart
 #' g = po("proxy", id = "preproc", param_vals = list(content = po("nop"))) %>>%
-#'   po("proxy", id = "learner", param_vals = list(content = lrn("classif.kknn")))
-#' rr_kknn = resample(task, learner = GraphLearner$new(g), resampling = rsmp("cv", folds = 3))
-#' rr_kknn$aggregate(msr("classif.ce"))
+#'   po("proxy", id = "learner", param_vals = list(content = lrn("classif.rpart")))
+#' rr_rpart = resample(task, learner = GraphLearner$new(g), resampling = rsmp("cv", folds = 3))
+#' rr_rpart$aggregate(msr("classif.ce"))
 #'
 #' # use pca for preprocessing and classif.rpart as the learner
 #' g$param_set$values$preproc.content = po("pca")

--- a/R/pipeline_stacking.R
+++ b/R/pipeline_stacking.R
@@ -25,13 +25,13 @@
 #' @return [`Graph`]
 #'
 #' @export
-#' @examplesIf mlr3misc::require_namespaces(c("rpart", "kknn"), quietly = TRUE)
+#' @examplesIf mlr3misc::require_namespaces("rpart", quietly = TRUE)
 #' library(mlr3)
 #' library(mlr3learners)
 #'
 #' base_learners = list(
 #'   lrn("classif.rpart", predict_type = "prob"),
-#'   lrn("classif.kknn", predict_type = "prob")
+#'   lrn("classif.nnet", predict_type = "prob")
 #' )
 #' super_learner = lrn("classif.log_reg")
 #'

--- a/man/mlr_graphs_stacking.Rd
+++ b/man/mlr_graphs_stacking.Rd
@@ -43,13 +43,13 @@ features in order to predict the outcome.
 All input arguments are cloned and have no references in common with the returned \code{\link{Graph}}.
 }
 \examples{
-\dontshow{if (mlr3misc::require_namespaces(c("rpart", "kknn"), quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (mlr3misc::require_namespaces("rpart", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(mlr3)
 library(mlr3learners)
 
 base_learners = list(
   lrn("classif.rpart", predict_type = "prob"),
-  lrn("classif.kknn", predict_type = "prob")
+  lrn("classif.nnet", predict_type = "prob")
 )
 super_learner = lrn("classif.log_reg")
 

--- a/man/mlr_pipeops_adas.Rd
+++ b/man/mlr_pipeops_adas.Rd
@@ -13,7 +13,7 @@ Generates a more balanced data set by creating synthetic instances of the minori
 The algorithm generates for each minority instance new data points based on its \code{K} nearest neighbors and the difficulty of learning for that data point.
 It can only be applied to tasks with numeric features that have no missing values.
 
-See \code{\link[smotefamily:ADAS]{smotefamily::ADAS}} for details.
+See \code{\link[smotefamily:adas]{smotefamily::ADAS}} for details.
 }
 \section{Construction}{
 
@@ -47,7 +47,7 @@ The parameters are the parameters inherited from \code{\link{PipeOpTaskPreproc}}
 \itemize{
 \item \code{K} :: \code{numeric(1)} \cr
 The number of nearest neighbors used for sampling new values. Default is \code{5}.
-See \code{\link[smotefamily:ADAS]{ADAS()}}.
+See \code{\link[smotefamily:adas]{ADAS()}}.
 }
 }
 

--- a/man/mlr_pipeops_datefeatures.Rd
+++ b/man/mlr_pipeops_datefeatures.Rd
@@ -106,7 +106,7 @@ library("mlr3")
 dat = iris
 set.seed(1)
 dat$date = sample(seq(as.POSIXct("2020-02-01"), to = as.POSIXct("2020-02-29"), by = "hour"),
- size = 150L)
+  size = 150L)
 task = TaskClassif$new("iris_date", backend = dat, target = "Species")
 pop = po("datefeatures", param_vals = list(cyclic = FALSE, minute = FALSE, second = FALSE))
 pop$train(list(task))

--- a/man/mlr_pipeops_imputelearner.Rd
+++ b/man/mlr_pipeops_imputelearner.Rd
@@ -104,11 +104,11 @@ new_task$missings()
 po$state$model$mass
 
 library("mlr3learners")
-# to use the "regr.kknn" Learner, prefix it with its own imputation method!
-# The "imputehist" PipeOp is used to train "regr.kknn"; predictions of this
+# To use the "regr.lm" Learner, prefix it with its own imputation method!
+# The "imputehist" PipeOp is used to train "regr.lm"; predictions of this
 # trained Learner are then used to impute the missing values in the Task.
 po = po("imputelearner",
-  po("imputehist") \%>>\% lrn("regr.kknn")
+  po("imputehist") \%>>\% lrn("regr.lm")
 )
 
 new_task = po$train(list(task = task))[[1]]

--- a/man/mlr_pipeops_nmf.Rd
+++ b/man/mlr_pipeops_nmf.Rd
@@ -96,7 +96,7 @@ See \code{\link[NMF:nmf]{nmf()}}.
 
 \section{Internals}{
 
-Uses the \code{\link[NMF:nmf]{nmf()}} function as well as \code{\link[NMF:basis]{basis()}}, \code{\link[NMF:coef]{coef()}} and
+Uses the \code{\link[NMF:nmf]{nmf()}} function as well as \code{\link[NMF:basis-coef-methods]{basis()}}, \code{\link[NMF:basis-coef-methods]{coef()}} and
 \code{\link[MASS:ginv]{ginv()}}.
 }
 

--- a/man/mlr_pipeops_proxy.Rd
+++ b/man/mlr_pipeops_proxy.Rd
@@ -76,17 +76,16 @@ Only methods inherited from \code{\link{PipeOp}}.
 \examples{
 \dontshow{if (requireNamespace("rpart")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library("mlr3")
-library("mlr3learners")
 
 set.seed(1234)
 task = tsk("iris")
 
 # use a proxy for preprocessing and a proxy for learning, i.e.,
-# no preprocessing and classif.kknn
+# no preprocessing and classif.rpart
 g = po("proxy", id = "preproc", param_vals = list(content = po("nop"))) \%>>\%
-  po("proxy", id = "learner", param_vals = list(content = lrn("classif.kknn")))
-rr_kknn = resample(task, learner = GraphLearner$new(g), resampling = rsmp("cv", folds = 3))
-rr_kknn$aggregate(msr("classif.ce"))
+  po("proxy", id = "learner", param_vals = list(content = lrn("classif.rpart")))
+rr_rpart = resample(task, learner = GraphLearner$new(g), resampling = rsmp("cv", folds = 3))
+rr_rpart$aggregate(msr("classif.ce"))
 
 # use pca for preprocessing and classif.rpart as the learner
 g$param_set$values$preproc.content = po("pca")


### PR DESCRIPTION
Since we removed `LearnerClassifKKNN` from mlr3learners, see https://github.com/mlr-org/mlr3learners/pull/339, because `kknn` was archived on CRAN.
closes https://github.com/mlr-org/mlr3pipelines/issues/910