### PR TITLE
Fixes to achieve compatibility with mlr3 weights update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Added missing error for predicting with untrained `PipeOp`s / `Graph`s.
 * Fix: Corrected typo in the hyperparameter name `use_parallel` of `PipeOpVtreat`.
+* Fix: New hyperparameter of `bbotk::OptimizerBatchNLoptr` does not get overwritten in `LearnerClassifAvg` / `LearnerRegrAvg`'s internal `optimize_weights_learneravg` function.
 
 # mlr3pipelines 0.7.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Added missing error for predicting with untrained `PipeOp`s / `Graph`s.
 * Fix: Corrected typo in the hyperparameter name `use_parallel` of `PipeOpVtreat`.
-* Fix: New hyperparameter of `bbotk::OptimizerBatchNLoptr` does not get overwritten in `LearnerClassifAvg` / `LearnerRegrAvg`'s internal `optimize_weights_learneravg` function.
+* Fix: Do not overwrite initial hyperparameter settings of `bbotk::OptimizerBatchNLoptr` in `LearnerClassifAvg` / `LearnerRegrAvg`'s internal `optimize_weights_learneravg` function.
 
 # mlr3pipelines 0.7.2
 

--- a/R/LearnerAvg.R
+++ b/R/LearnerAvg.R
@@ -194,7 +194,7 @@ optimize_weights_learneravg = function(self, task, n_weights, data) {
       if (inherits(optimizer, "character")) {
         optimizer = bbotk::opt(optimizer)
         if (inherits(optimizer, "OptimizerNLoptr") || inherits(optimizer, "OptimizerBatchNLoptr")) {
-          optimizer$param_set$values = list(xtol_rel = 1e-8, algorithm = "NLOPT_LN_COBYLA", start_values = "center")
+          optimizer$param_set$set_values(xtol_rel = 1e-8, algorithm = "NLOPT_LN_COBYLA", start_values = "center")
         }
       }
       measure = pars$measure

--- a/tests/testthat/test_GraphLearner.R
+++ b/tests/testthat/test_GraphLearner.R
@@ -10,6 +10,7 @@ test_that("basic graphlearner tests", {
 
   glrn = GraphLearner$new(gr)
   glrn$properties = setdiff(glrn$properties, "weights")  # FIXME: workaround until weights handling does not need to be part of the paramset
+  glrn$use_weights = "error"  # also need to update use_weights now
   expect_true(run_experiment(task, glrn)$ok)
   glrn$properties = c(glrn$properties, "weights")
 
@@ -40,8 +41,10 @@ test_that("basic graphlearner tests", {
   glrn2_clone = glrn2$clone(deep = TRUE)
   expect_learner(glrn2)
   glrn2$properties = setdiff(glrn2$properties, "weights")  # FIXME: see above
+  glrn2$use_weights = "error"  # see above
   expect_true(run_experiment(task, glrn2)$ok)
-  glrn2$properties = c(glrn2$properties, "weights")
+  glrn2$properties = c(glrn2$properties, "weights")  # reset changes
+  glrn2$use_weights = "use"  # reset changes
   glrn2$train(task)
   glrn2_clone$state = glrn2$state
 #  glrn2_clone$state$log = glrn2_clone$state$log$clone(deep = TRUE)  # FIXME: this can go when mlr-org/mlr3#343 is fixed

--- a/tests/testthat/test_GraphLearner.R
+++ b/tests/testthat/test_GraphLearner.R
@@ -10,7 +10,9 @@ test_that("basic graphlearner tests", {
 
   glrn = GraphLearner$new(gr)
   glrn$properties = setdiff(glrn$properties, "weights")  # FIXME: workaround until weights handling does not need to be part of the paramset
-  glrn$use_weights = "error"  # also need to update use_weights now
+  if ("use_weights" %in% names(glrn)) {  # FIXME: condition can be removed when mlr3 weights update, mlr3-org/mlr3#1124 is on CRAN
+    glrn$use_weights = "error"  # also need to update use_weights now
+  }
   expect_true(run_experiment(task, glrn)$ok)
   glrn$properties = c(glrn$properties, "weights")
 
@@ -41,10 +43,14 @@ test_that("basic graphlearner tests", {
   glrn2_clone = glrn2$clone(deep = TRUE)
   expect_learner(glrn2)
   glrn2$properties = setdiff(glrn2$properties, "weights")  # FIXME: see above
-  glrn2$use_weights = "error"  # see above
+  if ("use_weights" %in% names(glrn)) {  # FIXME: see above
+    glrn$use_weights = "error"  # see above
+  }
   expect_true(run_experiment(task, glrn2)$ok)
   glrn2$properties = c(glrn2$properties, "weights")  # reset changes
-  glrn2$use_weights = "use"  # reset changes
+  if ("use_weights" %in% names(glrn)) {  # FIXME: see above
+    glrn$use_weights = "use"  # reset changes
+  }
   glrn2$train(task)
   glrn2_clone$state = glrn2$state
 #  glrn2_clone$state$log = glrn2_clone$state$log$clone(deep = TRUE)  # FIXME: this can go when mlr-org/mlr3#343 is fixed

--- a/tests/testthat/test_GraphLearner.R
+++ b/tests/testthat/test_GraphLearner.R
@@ -43,13 +43,13 @@ test_that("basic graphlearner tests", {
   glrn2_clone = glrn2$clone(deep = TRUE)
   expect_learner(glrn2)
   glrn2$properties = setdiff(glrn2$properties, "weights")  # FIXME: see above
-  if ("use_weights" %in% names(glrn)) {  # FIXME: see above
-    glrn$use_weights = "error"  # see above
+  if ("use_weights" %in% names(glrn2)) {  # FIXME: see above
+    glrn2$use_weights = "error"  # see above
   }
   expect_true(run_experiment(task, glrn2)$ok)
   glrn2$properties = c(glrn2$properties, "weights")  # reset changes
-  if ("use_weights" %in% names(glrn)) {  # FIXME: see above
-    glrn$use_weights = "use"  # reset changes
+  if ("use_weights" %in% names(glrn2)) {  # FIXME: see above
+    glrn2$use_weights = "use"  # reset changes
   }
   glrn2$train(task)
   glrn2_clone$state = glrn2$state

--- a/tests/testthat/test_mlr_graphs_robustify.R
+++ b/tests/testthat/test_mlr_graphs_robustify.R
@@ -73,7 +73,6 @@ test_that("Robustify Pipeline", {
   dt = tsk$data()
   dt[2, 3] = NA
   tsk2 = TaskRegr$new(id = "bh", dt, target = "medv")
-  lrn$properties = c("multiclass", "twoclass")
   p = ppl("robustify", impute_missings = TRUE) %>>% po(lrn)
   g = GraphLearner$new(p)
   g$train(tsk)
@@ -100,7 +99,6 @@ test_that("Robustify Pipeline", {
   expect_true(length(p$pipeops) == 4)
 
 })
-
 
 
 test_that("Robustify Pipeline Impute Missings", {


### PR DESCRIPTION
closes https://github.com/mlr-org/mlr3pipelines/issues/912
- GraphLearner tests: `run_experiment` now checks behavior with weights and we had contradictory `$properties` (without `"weights"`) and `$use_weights` set to `"use"` since we modify the properties manually as some workaround (didn't check whether we still need that workaround).
- `ppl("robustify")` tests: Removed overwriting of `lrn$properties` that (1) deleted `"weights"` property necessary when calling `$.use_weights()` internally and (2) was seemingly illogical, overwriting the properties to `c("multiclass", "twoclass")` when that Learner was to be trained on a regression task.
- `LearnerRegrAvg` / `LearnerClassifAvg`: Now uses `$set_values()` to modify the ParamSet of OptimizerNloptr (which is used by default) to avoid overwriting the default value of its new hyperparameter `approximate_eval_grad_f` (https://github.com/mlr-org/bbotk/commit/9519f956a0a12b9a26644a74c1795eccaa005a5b).