### PR TITLE
Fixes `PipeOpImputeOOR` handling NAs only during predict

### DIFF
--- a/R/PipeOpImpute.R
+++ b/R/PipeOpImpute.R
@@ -22,7 +22,7 @@
 #'   Whether the `context_columns` parameter should be added which lets the user limit the columns that are
 #'   used for imputation inference. This should generally be `FALSE` if imputation depends only on individual features
 #'   (e.g. mode imputation), and `TRUE` if imputation depends on other features as well (e.g. kNN-imputation).
-#' * packages :: `character`\cr
+#' * `packages` :: `character`\cr
 #'   Set of all required packages for the [`PipeOp`]'s `private$.train` and `private$.predict` methods. See `$packages` slot.
 #'   Default is `character(0)`.
 #' * `task_type` :: `character(1)`\cr
@@ -98,10 +98,10 @@
 #'   (`atomic`, `character(1)`, [`data.table`][data.table::data.table]) -> `any`\cr
 #'   Like `.train_imputer()`, but only called for each feature that only contains missing values. This is not an abstract function
 #'   and, if not overloaded, gives a default response of `0` (`integer`, `numeric`), `c(TRUE, FALSE)` (`logical`), all available levels (`factor`/`ordered`),
-#'   or the empty  string (`character`).
+#'   or the empty string (`character`).
 #' * `.impute(feature, type, model, context)`\cr
 #'   (`atomic`, `character(1)`, `any`, [`data.table`][data.table::data.table]) -> `atomic`\cr
-#'   Imputes the features. `model` is the model created by `private$.train_imputer()` Default behaviour is to assume `model` is an atomic vector
+#'   Imputes the features. `model` is the model created by `private$.train_imputer()`. Default behaviour is to assume `model` is an atomic vector
 #'   from which values are sampled to impute missing values of `feature`. `model` may have an attribute `probabilities` for non-uniform sampling.
 #'
 #' @family PipeOps

--- a/R/PipeOpImputeConstant.R
+++ b/R/PipeOpImputeConstant.R
@@ -37,7 +37,7 @@
 #'   parameter and this will be checked during imputation. Initialized to `".MISSING"`.
 #' * `check_levels` :: `logical(1)`\cr
 #'   Should be checked whether the `constant` value is a valid level of factorial features (i.e., it
-#'   already is a level)? Raises an error if unsuccesful. This check is only performed for factorial
+#'   already is a level)? Raises an error if unsuccessful. This check is only performed for factorial
 #'   features (i.e., `factor`, `ordered`; skipped for `character`). Initialized to `TRUE`.
 #'
 #' @section Internals:

--- a/man/PipeOpImpute.Rd
+++ b/man/PipeOpImpute.Rd
@@ -26,7 +26,7 @@ subclass should have its own \code{param_vals} parameter and pass it on to \code
 Whether the \code{context_columns} parameter should be added which lets the user limit the columns that are
 used for imputation inference. This should generally be \code{FALSE} if imputation depends only on individual features
 (e.g. mode imputation), and \code{TRUE} if imputation depends on other features as well (e.g. kNN-imputation).
-\item packages :: \code{character}\cr
+\item \code{packages} :: \code{character}\cr
 Set of all required packages for the \code{\link{PipeOp}}'s \code{private$.train} and \code{private$.predict} methods. See \verb{$packages} slot.
 Default is \code{character(0)}.
 \item \code{task_type} :: \code{character(1)}\cr
@@ -120,10 +120,10 @@ is only called for features with at least one non-missing value.
 (\code{atomic}, \code{character(1)}, \code{\link[data.table:data.table]{data.table}}) -> \code{any}\cr
 Like \code{.train_imputer()}, but only called for each feature that only contains missing values. This is not an abstract function
 and, if not overloaded, gives a default response of \code{0} (\code{integer}, \code{numeric}), \code{c(TRUE, FALSE)} (\code{logical}), all available levels (\code{factor}/\code{ordered}),
-or the empty  string (\code{character}).
+or the empty string (\code{character}).
 \item \code{.impute(feature, type, model, context)}\cr
 (\code{atomic}, \code{character(1)}, \code{any}, \code{\link[data.table:data.table]{data.table}}) -> \code{atomic}\cr
-Imputes the features. \code{model} is the model created by \code{private$.train_imputer()} Default behaviour is to assume \code{model} is an atomic vector
+Imputes the features. \code{model} is the model created by \code{private$.train_imputer()}. Default behaviour is to assume \code{model} is an atomic vector
 from which values are sampled to impute missing values of \code{feature}. \code{model} may have an attribute \code{probabilities} for non-uniform sampling.
 }
 }

--- a/man/mlr_pipeops_imputeconstant.Rd
+++ b/man/mlr_pipeops_imputeconstant.Rd
@@ -49,7 +49,7 @@ atomic mode must match the type of the features that will be selected by the \co
 parameter and this will be checked during imputation. Initialized to \code{".MISSING"}.
 \item \code{check_levels} :: \code{logical(1)}\cr
 Should be checked whether the \code{constant} value is a valid level of factorial features (i.e., it
-already is a level)? Raises an error if unsuccesful. This check is only performed for factorial
+already is a level)? Raises an error if unsuccessful. This check is only performed for factorial
 features (i.e., \code{factor}, \code{ordered}; skipped for \code{character}). Initialized to \code{TRUE}.
 }
 }


### PR DESCRIPTION
closes https://github.com/mlr-org/mlr3pipelines/issues/894