### PR TITLE
perf: use more `setattr()` to avoid copys

### DIFF
--- a/R/PipeOpImputeSample.R
+++ b/R/PipeOpImputeSample.R
@@ -75,9 +75,7 @@ PipeOpImputeSample = R6Class("PipeOpImputeSample",
         # memory usage of count table is larger than memory usage of just the values
         return(fvals)
       }
-      model = tab$fvals
-      attr(model, "probabilities") = tab$N / sum(tab$N)
-      model
+      setattr(tab$fvals, "probabilities", tab$N / sum(tab$N))
     }
   )
 )

--- a/R/PipeOpLearnerPICVPlus.R
+++ b/R/PipeOpLearnerPICVPlus.R
@@ -197,7 +197,7 @@ PipeOpLearnerPICVPlus = R6Class("PipeOpLearnerPICVPlus",
 
       quantiles = as.matrix(map_dtr(seq_len(task$nrow), get_quantiles))
       quantiles = unname(quantiles)
-      attr(quantiles, "probs") = c(pv$alpha, 1 - pv$alpha)
+      setattr(quantiles, "probs", c(pv$alpha, 1 - pv$alpha))
 
       response = map_dbl(seq_len(task$nrow), function(observation) {
         stats::quantile(map_dbl(mu_hat, function(fold) {fold[observation, response]}), probs = 0.5)

--- a/R/PipeOpLearnerQuantiles.R
+++ b/R/PipeOpLearnerQuantiles.R
@@ -186,8 +186,8 @@ PipeOpLearnerQuantiles = R6Class("PipeOpLearnerQuantiles",
 
       quantiles = as.matrix(map_dtc(prds, "response"))
       unname(quantiles)
-      attr(quantiles, "probs") = pv$q_vals
-      attr(quantiles, "response") = pv$q_response
+      setattr(quantiles, "probs", pv$q_vals)
+      setattr(quantiles, "response", pv$q_response)
 
       # return quantile PredictionRegr with all requested quantiles
       list(as_prediction(as_prediction_data(list(quantiles = quantiles), task = task)))


### PR DESCRIPTION
Perhaps some of the `structure(...)` pattern could also be exchanged for it.