### PR TITLE
Fix: `PipeOpImputeLearner` no longer adds weird `"factor"` level

### DIFF
--- a/R/PipeOpImputeLearner.R
+++ b/R/PipeOpImputeLearner.R
@@ -169,7 +169,7 @@ PipeOpImputeLearner = R6Class("PipeOpImputeLearner",
 
       if (type %in% c("factor", "ordered")) {
         # in some edge cases there may be levels during training that are missing during predict.
-        levels(feature) = c(levels(feature), as.character(type))
+        levels(feature) = c(levels(feature), levels(imp_vals))
       }
 
       feature[nas] = imp_vals

--- a/tests/testthat/test_pipeop_imputelearner.R
+++ b/tests/testthat/test_pipeop_imputelearner.R
@@ -172,3 +172,21 @@ test_that("marshal", {
   expect_equal(s, su)
 })
 
+test_that("PipeOpImputeLearner - correct levels, #691", {
+  op = po("imputelearner", learner = lrn("classif.featureless"))
+  task = TaskRegr$new("test", target = "y", backend = data.table(
+    y = seq(1:5),
+    x1 = factor(c(NA, "a", "a", "b", "b")),
+    x2 = ordered(c(NA, "a", "a", "b", "b"))
+  ))
+
+  expect_equal(
+    op$train(list(task))[[1L]]$levels(),
+    list(x1 = c("a", "b"), x2 = c("a", "b"))
+  )
+  expect_equal(
+    op$predict(list(task))[[1L]]$levels(),
+    list(x1 = c("a", "b"), x2 = c("a", "b"))
+  )
+
+})


### PR DESCRIPTION
clsoes https://github.com/mlr-org/mlr3pipelines/issues/691