### PR TITLE
Adds a more informative `check_levels` error message for `PipeOpImputeConstant`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Fixed the error message for unexpected Multiplicities in the input and output type checking during `PipeOp`s training and prediction.
 * Untrained `PipeOp`s that take `NULL` as input during training now automatically perform training during prediction.
 * `PipeOpImputeConstant`, `PipeOpImputeMode`, `PipeOpImputeOOR`, and `PipeOpImputeLearner` can now handle `factor` or `ordered` features with zero levels.
+* `PipeOpImputeConstant` now gives a more informative error message if `check_levels` is `TRUE` and a new level would be created through imputation.
 
 # mlr3pipelines 0.8.0
 

--- a/R/PipeOpImputeConstant.R
+++ b/R/PipeOpImputeConstant.R
@@ -99,7 +99,10 @@ PipeOpImputeConstant = R6Class("PipeOpImputeConstant",
         "POSIXct"   = assert_posixct(constant, any.missing = FALSE, len = 1L)
       )
       if (type %in% c("ordered", "factor") && self$param_set$values$check_levels) {
-        assert_choice(as.character(constant), levels(feature))
+        if (!isTRUE(check_choice(as.character(constant), levels(feature)))) {
+          stopf("Constant '%s' is not an existing level of feature with levels {%s}, but hyperparameter 'check_levels' is TRUE.",
+                constant, str_collapse(levels(feature), quote = "'"))
+        }
       }
       if (type == "integer") {
         constant = as.integer(constant)

--- a/tests/testthat/test_pipeop_impute.R
+++ b/tests/testthat/test_pipeop_impute.R
@@ -334,12 +334,10 @@ test_that("More tests for PipeOpImputeConstant", {
   po = PipeOpImputeConstant$new()
 
   expect_error(po$train(list(task)), "Missing required parameters: constant")
-
   po$param_set$set_values(constant = "test")
-  # wrong type
-  expect_error(po$train(list(task)))
-
+  expect_error(po$train(list(task)), "Assertion .* failed: Must be of type 'number', not 'character'.")
   po$param_set$values$affect_columns = selector_type("character")
+
   train_out = po$train(list(task))[[1L]]
   expect_equal(train_out$feature_types, task$feature_types)
   expect_equal(sum(train_out$missings()), 7L)
@@ -352,7 +350,7 @@ test_that("More tests for PipeOpImputeConstant", {
   expect_equal(train_out$data(cols = "x2")[[1L]][1L], -999)
 
   po$param_set$values = list(constant = "test", check_levels = TRUE, affect_columns = selector_type("factor"))
-  expect_error(po$train(list(task))[[1L]])
+  expect_error(po$train(list(task))[[1L]], "Constant .* not an existing level of feature .*")
   po$param_set$values$check_levels = FALSE
   train_out = po$train(list(task))[[1L]]
   expect_equal(train_out$feature_types, task$feature_types)
@@ -362,7 +360,7 @@ test_that("More tests for PipeOpImputeConstant", {
   expect_equal(po$train(list(task))[[1L]]$data(cols = "x3")[[1L]][1L], factor("test", levels = c("1", "2", "test")))
 
   po$param_set$values = list(constant = "test", check_levels = TRUE, affect_columns = selector_type("ordered"))
-  expect_error(po$train(list(task))[[1L]])
+  expect_error(po$train(list(task))[[1L]], "Constant .* not an existing level of feature .*")
   po$param_set$values$check_levels = FALSE
   train_out = po$train(list(task))[[1L]]
   expect_equal(train_out$feature_types, task$feature_types)
@@ -476,7 +474,7 @@ test_that("Imputing zero level factors", {
     expect_equal(op$predict(list(task))[[1L]]$data(), dt_new_lvl)
   })
   op$param_set$set_values(check_levels = TRUE)
-  expect_error(op$train(list(task)), "Assertion.*failed.*element of set \\{\\}.*is 'new_lvl'")
+  expect_error(op$train(list(task)), "Constant .* not an existing level .* with levels \\{''\\}.*")
 
   # PipeOpImputeSample
   op = po("imputesample")


### PR DESCRIPTION
I forgot to add this with https://github.com/mlr-org/mlr3pipelines/pull/928.