### PR TITLE
Make tests compatable with upcoming `testthat` version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # mlr3pipelines 0.9.0-9000
 
+* Compatibility with new testthat version 3.3.0
 * Fix: Added internal workaround for `PipeOpNMF` attaching `Biobase`, `BiocGenerics`, and `generics` to the search path during training, prediction or when printing its `$state`.
-* feat: allow dates in datefeatures pipe op and use data.table for date feature generation
+* feat: allow dates in datefeatures pipe op and use data.table for date feature generation.
 * Added support for internal validation tasks to `PipeOpFeatureUnion`.
 
 # mlr3pipelines 0.9.0

--- a/tests/testthat/test_Graph.R
+++ b/tests/testthat/test_Graph.R
@@ -225,7 +225,8 @@ test_that("assert_graph test", {
 
   gr2 = assert_graph(gr)
 
-  expect_error(expect_deep_clone(gr, gr2), class = "error", regexp = "addresses differ.*isn't true|addresses differ.*is not TRUE")
+  expect_error(expect_deep_clone(gr, gr2), class = "error",
+    regexp = "Expected.*addresses differ.*to be TRUE|addresses differ.*isn't true|addresses differ.*is not TRUE")
 
   gr2 = as_graph(gr, clone = TRUE)
 
@@ -237,7 +238,8 @@ test_that("assert_graph test", {
 
   po = PipeOpNOP$new()
 
-  expect_error(expect_deep_clone(po, po), class = "error", regexp = "addresses differ.*isn't true|addresses differ.*is not TRUE")
+  expect_error(expect_deep_clone(po, po), class = "error",
+    regexp = "Expected.*addresses differ.*to be TRUE|addresses differ.*isn't true|addresses differ.*is not TRUE")
 
   po2 = as_graph(po, clone = TRUE)$pipeops[[1]]
 

--- a/tests/testthat/test_meta.R
+++ b/tests/testthat/test_meta.R
@@ -5,11 +5,11 @@ context("meta")
 test_that("expect_deep_clone catches non-deep clones", {
   po = PipeOpDebugBasic$new()
 
-  expect_error(expect_deep_clone(po, po))  # can't use expect_failure for some reason
+  expect_condition(expect_deep_clone(po, po), class = "expectation_failure")
   po1 = po$clone(deep = TRUE)
   expect_deep_clone(po, po1)
   po1$state = 1
-  expect_failure(expect_deep_clone(po, po1))
+  expect_condition(expect_deep_clone(po, po1), class = "expectation_failure")
 
   po$state = 1
   expect_deep_clone(po, po1)


### PR DESCRIPTION
closes https://github.com/mlr-org/mlr3pipelines/issues/957