### PR TITLE
Update S4 class coercion in `PipeOpTextVectorizer` to avoid deprecation warning from `Matrix`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # mlr3pipelines 0.10.0-9000
 
+* Fix: `PipeOpTextVectorizer` now uses coercion to `TsparseMatrix` instead of deprecated `dgTMatrix` to avoid `Matrix` deprecation warnings.
+
+
 # mlr3pipelines 0.10.0
 
 * Pretty-printing some info using the `cli` package now.

--- a/R/PipeOpTextVectorizer.R
+++ b/R/PipeOpTextVectorizer.R
@@ -322,7 +322,7 @@ PipeOpTextVectorizer = R6Class("PipeOpTextVectorizer",
       x = invoke(quanteda::dfm_weight, .args = c(list(x = tdm),
         rename_list(self$param_set$get_values("dfm_weight"), "_tf$", "")))
       v = docfreq
-      j = methods::as(x, "dgTMatrix")@j + 1L
+      j = methods::as(x, "TsparseMatrix")@j + 1L
       x@x = x@x * v[j]
       x
     }


### PR DESCRIPTION
Closes https://github.com/mlr-org/mlr3pipelines/issues/971