### PR TITLE
fix: add prototype args to FilterEnsemble

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -22,7 +22,7 @@ register_mlr3 = function() {
 register_mlr3filters = function() {
   if ("mlr3filters" %in% loadedNamespaces()) {
     x = utils::getFromNamespace("mlr_filters", ns = "mlr3filters")
-    x$add("ensemble", FilterEnsemble)
+    x$add("ensemble", FilterEnsemble, .prototype_args = list(filters = list(mlr3filters::FilterVariance$new(), mlr3filters::FilterAUC$new())))
   }
 }
 


### PR DESCRIPTION
This PR fixes:

```r
requireNamespace("mlr3pipelines")
library(mlr3filters)
 
as.data.table(mlr_filters)
# Error in assert_list(filters, types = "Filter", min.len = 1) : 
#   argument "filters" is missing, with no default
```

Only works with latest mlr3filters dev version. I will update mlr3filters on CRAN soon.