### PR TITLE
`PipeOp`s inheriting from `PipeOpTargetTrafo`  handle internal validation tasks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # mlr3pipelines 0.11.0-9000
 
+* Fix: `PipeOpTargetMutate` and `PipeOpTargetTrafoScaleRange` now correctly transform internal validation tasks during training.
+
 # mlr3pipelines 0.11.0
 
 * Fix: Made `FilterEnsemble` tests deterministic and more robust.

--- a/R/PipeOpTrafo.R
+++ b/R/PipeOpTrafo.R
@@ -624,10 +624,16 @@ PipeOpUpdateTarget = R6Class("PipeOpUpdateTarget",
   private = list(
     .train = function(inputs) {
       intask = inputs[[1]]$clone(deep = TRUE)
+      internal_valid_task = intask$internal_valid_task
+      intask$internal_valid_task = NULL
       pv = self$param_set$values
       if (identical(pv$trafo, identity) && (pv$new_target_name %in% unlist(intask$col_roles, use.names = FALSE))) {
         self$state = list()
-        return(list(private$.update_target(intask, drop_levels = TRUE)))  # early exit
+        intask = private$.update_target(intask, drop_levels = TRUE)
+        if (!is.null(internal_valid_task)) {
+          intask$internal_valid_task = private$.predict(list(internal_valid_task))[[1L]]
+        }
+        return(list(intask))  # early exit
       }
       if (!identical(pv$trafo, identity) || !is.null(pv$new_target_name)) {
         # Apply fun to target, rename, cbind and convert task if required
@@ -640,7 +646,11 @@ PipeOpUpdateTarget = R6Class("PipeOpUpdateTarget",
       } else {
         self$state = list()
       }
-      list(private$.update_target(intask, drop_levels = TRUE))
+      intask = private$.update_target(intask, drop_levels = TRUE)
+      if (!is.null(internal_valid_task)) {
+        intask$internal_valid_task = private$.predict(list(internal_valid_task))[[1L]]
+      }
+      list(intask)
     },
 
     .predict = function(inputs) {

--- a/R/PipeOpTrafo.R
+++ b/R/PipeOpTrafo.R
@@ -148,8 +148,13 @@ PipeOpTargetTrafo = R6Class("PipeOpTargetTrafo",
 
     .train = function(inputs) {
       intask = inputs[[1L]]$clone(deep = TRUE)
+      internal_valid_task = intask$internal_valid_task
+      intask$internal_valid_task = NULL
       self$state = private$.get_state(intask)
       intask = private$.transform(intask, "train")
+      if (!is.null(internal_valid_task)) {
+        intask$internal_valid_task = private$.transform(internal_valid_task, "predict")
+      }
       list(NULL, intask)
     },
 

--- a/tests/testthat/test_pipeop_targetmutate.R
+++ b/tests/testthat/test_pipeop_targetmutate.R
@@ -83,7 +83,7 @@ test_that("PipeOpTargetMutate - transforms internal validation task", {
   task = tsk("boston_housing")
   task$internal_valid_task = 1:10
 
-  validation_task = task$internal_valid_task$clone(deep = TRUE)
+  validation_task = task$internal_valid_task
   op = po("targetmutate",
     trafo = function(x) setNames(log(x), paste0(names(x), ".log"))
   )

--- a/tests/testthat/test_pipeop_targetmutate.R
+++ b/tests/testthat/test_pipeop_targetmutate.R
@@ -79,6 +79,26 @@ test_that("PipeOpTargetMutate - does not drop missing levels, #631", {
   expect_equal(task$levels(), predict_out$levels())
 })
 
+test_that("PipeOpTargetMutate - transforms internal validation task", {
+  task = tsk("boston_housing")
+  task$internal_valid_task = 1:10
+
+  validation_task = task$internal_valid_task$clone(deep = TRUE)
+  op = po("targetmutate",
+    trafo = function(x) setNames(log(x), paste0(names(x), ".log"))
+  )
+
+  train_out = op$train(list(task))[["output"]]
+  predict_out = op$predict(list(validation_task))[["output"]]
+
+  cols = unname(unlist(train_out$col_roles[c("feature", "target")]))
+  expect_equal(
+    train_out$internal_valid_task$data(cols = cols),
+    predict_out$data(cols = cols),
+    ignore.col.order = TRUE
+  )
+})
+
 test_that("PipeOpTargetMutate - error if trafo does not return dt/df/matrix", {
   task = tsk("boston_housing")
   op = po("targetmutate", trafo = function(x) 1)

--- a/tests/testthat/test_pipeop_targettrafoscalerange.R
+++ b/tests/testthat/test_pipeop_targettrafoscalerange.R
@@ -96,3 +96,21 @@ test_that("PipeOpTargetTrafoScaleRange - does not drop missing levels, #631", {
   expect_equal(task$levels(), train_out$levels())
   expect_equal(task$levels(), predict_out$levels())
 })
+
+test_that("PipeOpTargetTrafoScaleRange - transforms internal validation task", {
+  task = tsk("boston_housing")
+  task$internal_valid_task = 1:10
+
+  validation_task = task$internal_valid_task$clone(deep = TRUE)
+  po = PipeOpTargetTrafoScaleRange$new()
+
+  train_out = po$train(list(task))[["output"]]
+  predict_out = po$predict(list(validation_task))[["output"]]
+
+  cols = unname(unlist(train_out$col_roles[c("feature", "target")]))
+  expect_equal(
+    train_out$internal_valid_task$data(cols = cols),
+    predict_out$data(cols = cols),
+    ignore.col.order = TRUE
+  )
+})

--- a/tests/testthat/test_pipeop_targettrafoscalerange.R
+++ b/tests/testthat/test_pipeop_targettrafoscalerange.R
@@ -101,7 +101,7 @@ test_that("PipeOpTargetTrafoScaleRange - transforms internal validation task", {
   task = tsk("boston_housing")
   task$internal_valid_task = 1:10
 
-  validation_task = task$internal_valid_task$clone(deep = TRUE)
+  validation_task = task$internal_valid_task
   po = PipeOpTargetTrafoScaleRange$new()
 
   train_out = po$train(list(task))[["output"]]

--- a/tests/testthat/test_pipeop_updatetarget.R
+++ b/tests/testthat/test_pipeop_updatetarget.R
@@ -109,3 +109,24 @@ test_that("make an existing feature a target", {
   newtsk2 = pom$predict(list(tsk("wine")))[[1]]
   expect_equivalent(newtsk$hash, newtsk2$hash)
 })
+
+test_that("PipeOpUpdateTarget - transforms internal validation task", {
+  task = tsk("boston_housing_classic")
+  task$internal_valid_task = 1:10
+
+  validation_task = task$internal_valid_task$clone(deep = TRUE)
+  trafo_fun = function(x) {factor(ifelse(x < 25, "<25", ">=25"))}
+  op = PipeOpUpdateTarget$new(param_vals = list(
+    trafo = trafo_fun, new_target_name = "threshold_25", new_task_type = "classif"
+  ))
+
+  train_out = op$train(list(task))[["output"]]
+  predict_out = op$predict(list(validation_task))[["output"]]
+
+  cols = unname(unlist(train_out$col_roles[c("feature", "target")]))
+  expect_equal(
+    train_out$internal_valid_task$data(cols = cols),
+    predict_out$data(cols = cols),
+    ignore.col.order = TRUE
+  )
+})

--- a/tests/testthat/test_pipeop_updatetarget.R
+++ b/tests/testthat/test_pipeop_updatetarget.R
@@ -114,7 +114,7 @@ test_that("PipeOpUpdateTarget - transforms internal validation task", {
   task = tsk("boston_housing_classic")
   task$internal_valid_task = 1:10
 
-  validation_task = task$internal_valid_task$clone(deep = TRUE)
+  validation_task = task$internal_valid_task
   trafo_fun = function(x) {factor(ifelse(x < 25, "<25", ">=25"))}
   op = PipeOpUpdateTarget$new(param_vals = list(
     trafo = trafo_fun, new_target_name = "threshold_25", new_task_type = "classif"


### PR DESCRIPTION
Closes https://github.com/mlr-org/mlr3pipelines/issues/989