### PR TITLE
Simplified error message for `check_types()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * feat: `PipeOpSmote`, `PipeOpSmoteNC`, `PipeOpADAS`, and `PipeOpBLSmote` can now handle columns with role `"name"` by assigning the name `synthetic.<pipeop id>` to generated rows.
 * New `PipeOpMaterialize` that materializes the active `Task` view, reducing size and simplifying structure of the `Task`'s `DataBackend`.
 * Fix: `mlr_pipeops$add()` now saves the namespace environment from which it was called to allow delayed evaluation in `as.data.table(mlr_pipeops)`.
+* Simplified error messages from internal function `check_types()`. 
 
   
 # mlr3pipelines 0.11.0

--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -545,7 +545,18 @@ check_types = function(self, data, direction, operation) {
         ""
       }, error = function(e) sprintf("\nConversion from given data to %s produced message:\n%s.", typereq, e$message))
     }
-    assert_class(data_element, typereq, .var.name = paste0(varname, msg))
+
+    if (typereq %in% class(data_element)) {
+      return(data_element)
+    } else {
+      stop(sprintf(
+        "Type mismatch for %s: Must inherit from class '%s', but has class(es) %s. %s",
+        varname,
+        typereq,
+        str_collapse(class(data_element), quote = "'"),
+        msg
+      ), call. = FALSE)
+    }
   }
 
   for (idx in seq_along(data)) {

--- a/R/PipeOp.R
+++ b/R/PipeOp.R
@@ -546,7 +546,7 @@ check_types = function(self, data, direction, operation) {
       }, error = function(e) sprintf("\nConversion from given data to %s produced message:\n%s.", typereq, e$message))
     }
 
-    if (typereq %in% class(data_element)) {
+    if (inherits(data_element, typereq)) {
       return(data_element)
     } else {
       stop(sprintf(

--- a/tests/testthat/test_multiplicities.R
+++ b/tests/testthat/test_multiplicities.R
@@ -132,18 +132,18 @@ test_that("Graph - add_edge", {
 test_that("Multiplicity checking", {
   p = po("pca")
 
-  expect_error(p$train(list(x = 1)), "Assertion on 'input 1 \\(\"input\"\\) of PipeOp pca's \\$train\\(\\)")
+  expect_error(p$train(list(x = 1)), "Must inherit from class.*Task.*but has class.*numeric")
   expect_task(p$train(list(x = tsk("iris")))[[1]])
 
   expect_task(p$predict(list(x = tsk("iris")))[[1]])
-  expect_error(p$predict(list(x = 1)), "Assertion on 'input 1 \\(\"input\"\\) of PipeOp pca's \\$predict\\(\\)")
+  expect_error(p$predict(list(x = 1)), "Must inherit from class.*Task.*but has class.*numeric")
 
   p$output$predict = "numeric"
 
   expect_task(p$train(list(x = tsk("iris")))[[1]])
-  expect_error(p$predict(list(x = tsk("iris")))[[1]], "Assertion on 'output 1 \\(\"output\"\\) of PipeOp pca's \\$predict\\(\\)")
+  expect_error(p$predict(list(x = tsk("iris")))[[1]], "Must inherit from class.*numeric.*but has class.*TaskClassif.*TaskSupervised.*Task.*R6'")
 
   p$output$train = "numeric"
-  expect_error(p$train(list(x = tsk("iris")))[[1]], "Assertion on 'output 1 \\(\"output\"\\) of PipeOp pca's \\$train\\(\\)")
+  expect_error(p$train(list(x = tsk("iris")))[[1]], "Must inherit from class.*numeric.*but has class.*TaskClassif.*TaskSupervised.*Task.*R6'")
 
 })

--- a/tests/testthat/test_preproc.R
+++ b/tests/testthat/test_preproc.R
@@ -58,8 +58,8 @@ test_that("preproc - basic sanity checks", {
       .predict = function(inputs) list(as.character(inputs[[1L]]))
     )
   )
-  expect_error(preproc(task, PipeOpDebugNonTaskInput$new()), "Must inherit from class '.*', but has classes.*'Task'")
-  expect_error(preproc(task, po("regravg"), state = list(), predict = TRUE), "Must inherit from class '.*', but has classes.*'Task'")
+  expect_error(preproc(task, PipeOpDebugNonTaskInput$new()), "Must inherit from class '.*', but has class.*'Task'")
+  expect_error(preproc(task, po("regravg"), state = list(), predict = TRUE), "Must inherit from class '.*', but has class.*'Task'")
 
   # Test error for processors incapable of handling targetless tasks when indata is a data.frame
   expect_error(preproc(task$data(), po("smote")), "Must inherit from class 'TaskClassif'")


### PR DESCRIPTION
Closes https://github.com/mlr-org/mlr3pipelines/issues/905

Old error message:
> Error in check_item(data[[idx]], typetable[[operation]][[idx]], varname = sprintf("%s %s (\"%s\") of PipeOp %s's $%s()",  : 
  Assertion on 'input 1 ("input") of PipeOp smote's $train()' failed: Must inherit from class 'TaskClassif', but has classes 'TaskUnsupervised','Task','R6'.

New error message:
> Error: Type mismatch for input 1 ("input") of PipeOp smote's $train(): Must inherit from class 'TaskClassif', but has class(es) 'TaskUnsupervised', 'Task', 'R6'. 
