### PR TITLE
feat(targetinvert): propagate the prediction extra slot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 * `mlr_graphs` no longer overrides the inherited `$add()` method.
 * Simplified error messages from internal function `check_types()`. 
 * Removed deprecated `greplicate()` function. Use `ppl("greplicate")` instead.
-
+* `PipeOpTargetInvert` now propagates the `extra` slot of input prediction objects to the output prediction object, if the inverter `fun` does not handle it already.  
   
 # mlr3pipelines 0.11.0
 

--- a/R/PipeOpTrafo.R
+++ b/R/PipeOpTrafo.R
@@ -279,6 +279,7 @@ PipeOpTargetInvert = R6Class("PipeOpTargetInvert",
 
     .predict = function(inputs) {
       output = inputs[[1L]](inputs[-1L])
+      # Keep "extra" slot if inverter does not handle it already
       extra = inputs[[2L]]$data$extra
       if (!is.null(extra) && is.null(output[[1L]]$data$extra)) {
         output[[1L]]$data$extra = extra

--- a/R/PipeOpTrafo.R
+++ b/R/PipeOpTrafo.R
@@ -278,7 +278,12 @@ PipeOpTargetInvert = R6Class("PipeOpTargetInvert",
     },
 
     .predict = function(inputs) {
-      inputs[[1]](inputs[-1])
+      output = inputs[[1L]](inputs[-1L])
+      extra = inputs[[2L]]$data$extra
+      if (!is.null(extra) && is.null(output[[1L]]$data$extra)) {
+        output[[1L]]$data$extra = extra
+      }
+      output
     }
   )
 )

--- a/tests/testthat/test_pipeop_targetinvert.R
+++ b/tests/testthat/test_pipeop_targetinvert.R
@@ -9,3 +9,36 @@ test_that("PipeOpTargetInvert - basic properties", {
   expect_data_table(po$input, nrows = 2L)
   expect_data_table(po$output, nrows = 1L)
 })
+
+test_that("PipeOpTargetInvert propagates extra prediction data", {
+  po = PipeOpTargetInvert$new()
+  po$train(list(NULL, NULL))
+
+  prediction = PredictionRegr$new(
+    row_ids = 1:3,
+    truth = 1:3,
+    response = 4:6
+  )
+  prediction$data$extra = list(source = "learner", values = 7:9)
+
+  inverter = function(inputs) {
+    prediction = inputs[[1L]]
+    list(PredictionRegr$new(
+      row_ids = prediction$row_ids,
+      truth = prediction$truth,
+      response = prediction$response * 2
+    ))
+  }
+  output = po$predict(list(inverter, prediction))[[1L]]
+
+  expect_identical(output$data$extra, prediction$data$extra)
+
+  inverter = function(inputs) {
+    output = inputs[[1L]]$clone(deep = TRUE)
+    output$data$extra = list(source = "inverter")
+    list(output)
+  }
+  output = po$predict(list(inverter, prediction))[[1L]]
+
+  expect_identical(output$data$extra, list(source = "inverter"))
+})


### PR DESCRIPTION
The extra slot is currently dropped, causing an issue for extension packages that rely on the extra slot provided in mlr3. Since it's a target trafo I would argue that the no-op for the extra slot is a simple decision.