### PR TITLE
Fix GraphLearner cloning and test dormant spline values

### DIFF
--- a/R/GraphLearner.R
+++ b/R/GraphLearner.R
@@ -472,6 +472,15 @@ GraphLearner = R6Class("GraphLearner", inherit = Learner,
       }
       if (name == "state") {
         value$log = copy(value$log)
+        if (!is.null(value$param_vals)) {
+          value$param_vals = map(value$param_vals, function(x) {
+            if (is.environment(x) && !is.null(x[[".__enclos_env__"]])) {
+              x$clone(deep = TRUE)
+            } else {
+              x
+            }
+          })
+        }
       }
       value
     },

--- a/tests/testthat/test_dictionary.R
+++ b/tests/testthat/test_dictionary.R
@@ -113,6 +113,7 @@ test_that("Dictionary contains all PipeOps", {
     expect_false(isTRUE(all.equal(other_obj$hash, test_obj$hash)), info = paste(dictname, "$new id test"))
     expect_false(isTRUE(all.equal(other_obj$phash, test_obj$phash)), info = paste(dictname, "$new id test"))
     test_obj$id = "TESTID"
+    test_obj = inflate(test_obj)
     other_obj = inflate(do.call(mlr_pipeops$get, c(list(dictname), args)))
     expect_equal(other_obj, test_obj, info = paste(dictname, "$new id test 2"))
     if (!dictname %in% pval_unhashable) {

--- a/tests/testthat/test_pipeop_proxy.R
+++ b/tests/testthat/test_pipeop_proxy.R
@@ -174,8 +174,16 @@ test_that("Cloning as expected", {
 
   lg2 = lg$clone(deep = TRUE)
 
+  expect_false(identical(
+    lg$state$param_vals$proxy.content,
+    lg2$state$param_vals$proxy.content
+  ))
   expect_deep_clone(lg, lg2)
 
   expect_deep_clone(lg$param_set$values$proxy.content, lg2$param_set$values$proxy.content)
+
+  original_center = lg$state$param_vals$proxy.content$param_set$values$center
+  lg2$state$param_vals$proxy.content$param_set$values$center = !original_center
+  expect_identical(lg$state$param_vals$proxy.content$param_set$values$center, original_center)
 
 })

--- a/tests/testthat/test_pipeop_splines.R
+++ b/tests/testthat/test_pipeop_splines.R
@@ -9,9 +9,19 @@ test_that("PipeOpSplines - basic properties", {
   # when we train we get the Boundary.knots, when we now predict on the same data the results will change
 })
 
-test_that("Error when trying to pass degree argument while type = natural", {
+test_that("degree follows the Paradox dormant-value contract", {
   skip_if_not_installed("splines")
-  expect_error(po("splines", type = "natural", degree = 3))
+  if (packageVersion("paradox") < "2.0.0") {
+    expect_error(po("splines", type = "natural", degree = 3))
+  } else {
+    splines = po("splines", type = "natural", degree = 3)
+
+    expect_identical(splines$param_set$values$degree, 3L)
+    expect_false("degree" %in% names(splines$param_set$get_values()))
+
+    splines$param_set$values$type = "polynomial"
+    expect_identical(splines$param_set$get_values()$degree, 3L)
+  }
 })
 
 test_that("results are identical as when calculating by hand", {
@@ -137,4 +147,3 @@ test_that("Boundary Knots and Knots", {
     }
   }
 })
-


### PR DESCRIPTION
> Deep-clone mutable R6 values stored in `GraphLearner$state$param_vals` so a
> cloned learner cannot mutate the original learner through shared proxy
> content. The previous test happened to pass with Paradox 1 because its
> traversal encountered an alias through private ParamSet storage first;
> Paradox 2's detached capsule layout exposed the existing ownership bug. Add
> an explicit identity and mutation-isolation regression that catches it under
> both Paradox versions.
>
> Also make the existing spline dependency assertion dual-version: Paradox 1
> keeps its historical inactive-assignment error, while Paradox 2 retains the
> dormant degree in raw values, filters it for a natural spline, and reveals it
> when the type becomes polynomial.
>
> Inflate the expected dictionary object as well as the observed object before
> comparing them. This makes the assertion symmetric and valid with both the
> Paradox 1 and Paradox 2 public shells.
