### PR TITLE
Remove outdated FIXMEs in `PipeOpLearner.R` and `PipeOpLearnerCV.R`

### DIFF
--- a/R/PipeOpLearner.R
+++ b/R/PipeOpLearner.R
@@ -102,7 +102,6 @@ PipeOpLearner = R6Class("PipeOpLearner", inherit = PipeOp,
           id
         )
       }
-      # FIXME: can be changed when mlr-org/mlr3#470 has an answer
       type = private$.learner$task_type
       task_type = mlr_reflections$task_types[type, mult = "first"]$task
       out_type = mlr_reflections$task_types[type, mult = "first"]$prediction

--- a/R/PipeOpLearnerCV.R
+++ b/R/PipeOpLearnerCV.R
@@ -148,7 +148,6 @@ PipeOpLearnerCV = R6Class("PipeOpLearnerCV",
     initialize = function(learner, id = NULL, param_vals = list()) {
       private$.learner = as_learner(learner, clone = TRUE)
       id = id %??% private$.learner$id
-      # FIXME: can be changed when mlr-org/mlr3#470 has an answer
       type = private$.learner$task_type
       task_type = mlr_reflections$task_types[type, mult = "first"]$task
 


### PR DESCRIPTION
Closes https://github.com/mlr-org/mlr3pipelines/issues/655
Current contract no longer allows a vector of task types in `mlr_reflections`.