### PR TITLE
Preserve extension-registered pipeop properties in register_mlr3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # mlr3pipelines 0.11.0-9000
 
+* Fix: Re-running registration (e.g. when `mlr3` is reloaded) no longer removes `PipeOp` properties added to `mlr_reflections$pipeops$properties` by extension packages.
 * Switched from using `digest::digest()` to using `mlr3misc::calculate_hash()` for calculating the `hash` and `phash` of `PipeOp`s, `Graph`s, and `GraphLearner`s.
 * Fix: Corrected registration of `FilterEnsemble` in `mlr_filters` using `.prototype_args`.
 * Fix: `PipeOpTargetMutate` and `PipeOpTargetTrafoScaleRange` now correctly transform internal validation tasks during training.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -16,7 +16,7 @@ register_mlr3 = function() {
     c("abstract", "meta", "missings", "feature selection", "imbalanced data",
     "data transform", "target transform", "ensemble", "robustify", "learner", "encode",
      "multiplicity", "debug")))
-  x$pipeops$properties = c("validation", "internal_tuning")
+  x$pipeops$properties = unique(c(x$pipeops$properties, c("validation", "internal_tuning")))
 }
 
 register_mlr3filters = function() {


### PR DESCRIPTION
register_mlr3() overwrote mlr_reflections$pipeops$properties with a plain assignment, unlike valid_tags on the line above. Since it is hooked on packageEvent("mlr3", "onLoad"), any mlr3 reload wiped properties registered by extension packages (e.g. mlr3forecast's "fcst_iterative").