### PR TITLE
Suppress ` exportS3method` warnings during `devtools::document()`

### DIFF
--- a/R/CnfAtom.R
+++ b/R/CnfAtom.R
@@ -182,6 +182,7 @@ all.equal.CnfAtom = function(target, current, ...) {
   all.equal.list(target, current, ...)
 }
 
+#' @exportS3Method NULL
 #' @rawNamespace if (getRversion() >= "4.3.0") S3method(chooseOpsMethod,CnfAtom)
 chooseOpsMethod.CnfAtom <- function(x, y, mx, my, cl, reverse) TRUE
 

--- a/R/CnfClause.R
+++ b/R/CnfClause.R
@@ -277,6 +277,7 @@ all.equal.CnfClause = function(target, current, ...) {
   all.equal.list(target, current, ...)
 }
 
+#' @exportS3Method NULL
 #' @rawNamespace if (getRversion() >= "4.3.0") S3method(chooseOpsMethod,CnfClause)
 chooseOpsMethod.CnfClause <- function(x, y, mx, my, cl, reverse) TRUE
 

--- a/R/CnfFormula.R
+++ b/R/CnfFormula.R
@@ -302,6 +302,7 @@ all.equal.CnfFormula = function(target, current, ...) {
   all.equal.list(target, current, ...)
 }
 
+#' @exportS3Method NULL
 #' @rawNamespace if (getRversion() >= "4.3.0") S3method(chooseOpsMethod,CnfFormula)
 chooseOpsMethod.CnfFormula <- function(x, y, mx, my, cl, reverse) TRUE
 

--- a/man/mlr_pipeops_blsmote.Rd
+++ b/man/mlr_pipeops_blsmote.Rd
@@ -98,8 +98,7 @@ table(bls_result$result)
 Han H, Wang W, Mao B (2005).
 \dQuote{Borderline-SMOTE: A New Over-Sampling Method in Imbalanced Data Sets Learning.}
 In Huang D, Zhang X, Huang G (eds.), \emph{Advances in Intelligent Computing}, 878--887.
-ISBN 978-3-540-31902-3.
-\doi{10.1007/11538059_91}.
+ISBN 978-3-540-31902-3, \doi{10.1007/11538059_91}.
 }
 \seealso{
 https://mlr-org.com/pipeops.html


### PR DESCRIPTION
Using `devtools::document()` currently returns the following warnings:
```
✖ CnfClause.R:281: S3 method `chooseOpsMethod.CnfClause`
  needs @export or @exportS3Method tag.
✖ CnfFormula.R:306:: S3 method `chooseOpsMethod.CnfFormula`
  needs @export or @exportS3Method tag.
✖ CnfAtom.R:186: S3 method `chooseOpsMethod.CnfAtom` needs
  @export or @exportS3Method tag.
```

However, these already get handled in a backwards-compatible manner:
```
#' @rawNamespace if (getRversion() >= "4.3.0") S3method(chooseOpsMethod,CnfAtom)
```

This adds the [official, suggested workaround](https://roxygen2.r-lib.org/reference/tags-namespace.html) to suppress these warnings.